### PR TITLE
Update test to expect specific exception type for invalid private key

### DIFF
--- a/core/src/test/java/org/codelibs/saml2/core/test/util/UtilsTest.java
+++ b/core/src/test/java/org/codelibs/saml2/core/test/util/UtilsTest.java
@@ -618,8 +618,7 @@ public class UtilsTest {
     public void testGetNameIdDataWrongKey() throws Exception {
         String keyString = Util.getFileAsString("data/misc/sp3.key");
 
-        expectedEx.expect(Exception.class);
-        expectedEx.expectMessage("algid parse error, not a sequence");
+        expectedEx.expect(InvalidKeySpecRuntimeException.class);
         Util.loadPrivateKey(keyString);
     }
 


### PR DESCRIPTION
This pull request updates the UtilsTest class to refine the test testGetNameIdDataWrongKey. The expected exception type has been changed from a generic Exception to a specific InvalidKeySpecRuntimeException, improving the precision of the test and better reflecting the actual behavior of the method Util.loadPrivateKey.
