### PR TITLE
build: attach javadoc jar to release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,14 @@
 						<locale>en_US</locale>
 						<source>17</source>
 					</configuration>
+					<executions>
+						<execution>
+							<id>attach-javadocs</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
## Summary
Release builds did not generate javadoc jars because maven-javadoc-plugin in the root pluginManagement had no jar goal execution, while the core and toolkit modules only declare the plugin without executions. The super POM release-profile that used to handle this is no longer available in current Maven versions, so publishing to Maven Central fails validation during `mvn release:perform`. Sources jars were already covered by the existing maven-source-plugin execution.

## Changes Made
- Add an `attach-javadocs` execution (`jar` goal) to maven-javadoc-plugin in the root `pluginManagement`, which the core and toolkit modules inherit

## Testing
- Ran `mvn package -DskipTests -pl core` and confirmed that `java-saml-core-*-javadoc.jar` is generated alongside the sources jar

## Additional Notes
- Same fix as codelibs/opensearch-runner#20 (codelibs/opensearch-runner@25c54af)