### PR TITLE
build: move release-only plugins to release profile

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,17 +83,11 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,13 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>3.1.1</version>
+				<configuration>
+					<releaseProfiles>release</releaseProfiles>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
 				<version>0.10.0</version>
@@ -179,6 +186,12 @@
 			<id>release</id>
 			<build>
 				<plugins>
+					<plugin>
+						<artifactId>maven-source-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<artifactId>maven-javadoc-plugin</artifactId>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>

--- a/toolkit/pom.xml
+++ b/toolkit/pom.xml
@@ -92,17 +92,11 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
-			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
 			</plugin>
 			<plugin>
 				<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
## Summary
Standardize the release configuration following the maven-release-plugin 2→3 migration guide (https://maven.apache.org/maven-release/maven-release-plugin/migrate.html): release-only plugins now run via the `release` profile, which maven-release-plugin activates automatically during `release:perform`.

## Changes Made
- Added maven-release-plugin 3.1.1 with `<releaseProfiles>release</releaseProfiles>` to the parent build
- Moved the maven-source-plugin / maven-javadoc-plugin references from the `core` and `toolkit` module builds into the parent `release` profile (versions and executions are still managed in `pluginManagement`), so sources/javadoc jars are generated only during releases, alongside GPG signing

## Testing
- `mvn package -DskipTests` — no sources/javadoc jars produced in any module, no GPG required for local builds
- `mvn package -P release -DskipTests -Dgpg.skip=true` — core and toolkit both produce sources and javadoc jars

## Breaking Changes
- None (release artifacts are unchanged)

## Additional Notes
- Plain `mvn install` no longer attaches sources/javadoc jars locally; they are generated only during releases.
- Same pattern as codelibs/fesen-httpclient; applied across CodeLibs repositories for consistency.