### PR TITLE
fix: resolve Javadoc warnings

### DIFF
--- a/core/src/main/java/org/codelibs/saml2/core/authn/AuthnRequest.java
+++ b/core/src/main/java/org/codelibs/saml2/core/authn/AuthnRequest.java
@@ -141,6 +141,8 @@ public class AuthnRequest {
     }
 
     /**
+     * Returns the base64 encoded, unsigned AuthnRequest, optionally deflated.
+     *
      * @return the base64 encoded unsigned AuthnRequest (deflated or not)
      *
      * @param deflated
@@ -161,6 +163,8 @@ public class AuthnRequest {
     }
 
     /**
+     * Returns the base64 encoded, unsigned AuthnRequest using the default deflate setting.
+     *
      * @return base64 encoded, unsigned AuthnRequest (deflated or not)
      *
      */
@@ -169,6 +173,8 @@ public class AuthnRequest {
     }
 
     /**
+     * Returns the unsigned plain-text AuthnRequest XML.
+     *
      * @return unsigned plain-text AuthnRequest.
      */
     public String getAuthnRequestXml() {
@@ -281,6 +287,8 @@ public class AuthnRequest {
     }
 
     /**
+     * Returns the generated id of the AuthnRequest message.
+     *
      * @return the generated id of the AuthnRequest message
      */
     public String getId() {

--- a/core/src/main/java/org/codelibs/saml2/core/authn/AuthnRequestParams.java
+++ b/core/src/main/java/org/codelibs/saml2/core/authn/AuthnRequestParams.java
@@ -127,6 +127,8 @@ public class AuthnRequestParams {
     }
 
     /**
+     * Returns whether the <code>ForceAuthn</code> attribute should be set.
+     *
      * @return whether the <code>ForceAuthn</code> attribute should be set to
      *         <code>true</code>
      */
@@ -135,6 +137,8 @@ public class AuthnRequestParams {
     }
 
     /**
+     * Returns whether the <code>IsPassive</code> attribute should be set.
+     *
      * @return whether the <code>IsPassive</code> attribute should be set to
      *         <code>true</code>
      */
@@ -143,6 +147,8 @@ public class AuthnRequestParams {
     }
 
     /**
+     * Returns whether a <code>NameIDPolicy</code> should be set.
+     *
      * @return whether a <code>NameIDPolicy</code> should be set
      */
     public boolean isSetNameIdPolicy() {
@@ -150,6 +156,8 @@ public class AuthnRequestParams {
     }
 
     /**
+     * Returns whether the <code>AllowCreate</code> attribute should be set on the <code>NameIDPolicy</code>.
+     *
      * @return whether the <code>AllowCreate</code> attribute should be set to
      *         <code>true</code> on the <code>NameIDPolicy</code> element (only
      *         meaningful if {@link #isSetNameIdPolicy()} is also <code>true</code>)
@@ -159,6 +167,8 @@ public class AuthnRequestParams {
     }
 
     /**
+     * Returns the subject that should be authenticated.
+     *
      * @return the subject that should be authenticated
      */
     public String getNameIdValueReq() {

--- a/core/src/main/java/org/codelibs/saml2/core/authn/SamlResponse.java
+++ b/core/src/main/java/org/codelibs/saml2/core/authn/SamlResponse.java
@@ -623,7 +623,7 @@ public class SamlResponse {
     /**
      * Returns the ResponseStatus object
      *
-     * @return
+     * @return the response status
      */
     public SamlResponseStatus getResponseStatus() {
         return this.responseStatus;
@@ -848,6 +848,8 @@ public class SamlResponse {
     }
 
     /**
+     * Returns the ID of the Response.
+     *
      * @return the ID of the Response
      */
     public String getId() {
@@ -855,6 +857,8 @@ public class SamlResponse {
     }
 
     /**
+     * Returns the ID of the assertion in the Response.
+     *
      * @return the ID of the assertion in the Response
      *
      */
@@ -867,6 +871,8 @@ public class SamlResponse {
     }
 
     /**
+     * Returns the NotOnOrAfter values of this Response.
+     *
      * @return a list of NotOnOrAfter values from SubjectConfirmationData nodes in this Response
      *
      */
@@ -1220,6 +1226,8 @@ public class SamlResponse {
     }
 
     /**
+     * Returns the SAMLResponse XML.
+     *
      * @return the SAMLResponse XML, If the Assertion of the SAMLResponse was encrypted,
      *         returns the XML with the assertion decrypted
      */
@@ -1234,6 +1242,8 @@ public class SamlResponse {
     }
 
     /**
+     * Returns the SAMLResponse Document.
+     *
      * @return the SAMLResponse Document, If the Assertion of the SAMLResponse was encrypted,
      *         returns the Document with the assertion decrypted
      */

--- a/core/src/main/java/org/codelibs/saml2/core/exception/InvalidKeySpecRuntimeException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/InvalidKeySpecRuntimeException.java
@@ -2,10 +2,19 @@ package org.codelibs.saml2.core.exception;
 
 import java.security.spec.InvalidKeySpecException;
 
+/**
+ * Runtime exception wrapping an {@link InvalidKeySpecException}.
+ */
 public class InvalidKeySpecRuntimeException extends RuntimeException {
 
+    /** Serial version UID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new {@code InvalidKeySpecRuntimeException} wrapping the given key spec exception.
+     *
+     * @param e the underlying invalid key spec exception
+     */
     public InvalidKeySpecRuntimeException(InvalidKeySpecException e) {
         super(e);
     }

--- a/core/src/main/java/org/codelibs/saml2/core/exception/SAMLSevereException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/SAMLSevereException.java
@@ -1,29 +1,60 @@
 package org.codelibs.saml2.core.exception;
 
+/**
+ * Exception thrown when a severe, non-recoverable SAML error occurs.
+ * Each instance carries an error code identifying the specific severe condition.
+ */
 public class SAMLSevereException extends SAMLException {
 
+    /** Serialization version identifier. */
     private static final long serialVersionUID = 1L;
 
+    /** Error code indicating that the settings file could not be found. */
     public static final int SETTINGS_FILE_NOT_FOUND = 1;
+    /** Error code indicating that the service provider metadata is invalid. */
     public static final int METADATA_SP_INVALID = 2;
+    /** Error code indicating that the SAML response was not found. */
     public static final int SAML_RESPONSE_NOT_FOUND = 3;
+    /** Error code indicating that the SAML logout message was not found. */
     public static final int SAML_LOGOUTMESSAGE_NOT_FOUND = 4;
+    /** Error code indicating that the SAML logout request is invalid. */
     public static final int SAML_LOGOUTREQUEST_INVALID = 5;
+    /** Error code indicating that the SAML logout response is invalid. */
     public static final int SAML_LOGOUTRESPONSE_INVALID = 6;
+    /** Error code indicating that single logout is not supported. */
     public static final int SAML_SINGLE_LOGOUT_NOT_SUPPORTED = 7;
 
+    /** The error code identifying the specific severe condition. */
     private final int errorCode;
 
+    /**
+     * Constructs a new severe exception with the given message and error code.
+     *
+     * @param message the detail message describing the error
+     * @param errorCode the error code identifying the severe condition
+     */
     public SAMLSevereException(final String message, final int errorCode) {
         super(message);
         this.errorCode = errorCode;
     }
 
+    /**
+     * Constructs a new severe exception with the given message, error code, and cause.
+     *
+     * @param message the detail message describing the error
+     * @param errorCode the error code identifying the severe condition
+     * @param cause the underlying cause of this exception
+     */
     public SAMLSevereException(final String message, final int errorCode, final Throwable cause) {
         super(message, cause);
         this.errorCode = errorCode;
     }
 
+    /**
+     * Returns the error code identifying the specific severe condition.
+     *
+     * @return the error code
+     */
     public int getErrorCode() {
         return errorCode;
     }

--- a/core/src/main/java/org/codelibs/saml2/core/exception/SAMLSignatureException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/SAMLSignatureException.java
@@ -1,9 +1,18 @@
 package org.codelibs.saml2.core.exception;
 
+/**
+ * Exception thrown when a SAML signature operation fails.
+ */
 public class SAMLSignatureException extends SAMLException {
 
+    /** Serial version UID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new {@code SAMLSignatureException} wrapping the given exception.
+     *
+     * @param e the underlying exception
+     */
     public SAMLSignatureException(Exception e) {
         super(e);
     }

--- a/core/src/main/java/org/codelibs/saml2/core/exception/SettingsException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/SettingsException.java
@@ -1,23 +1,46 @@
 package org.codelibs.saml2.core.exception;
 
+/**
+ * Exception thrown when an error related to SAML settings configuration occurs.
+ * Each instance carries an error code identifying the specific settings problem.
+ */
 public class SettingsException extends SAMLException {
 
+    /** Serialization version identifier. */
     private static final long serialVersionUID = 1L;
 
+    /** Error code indicating that the settings syntax is invalid. */
     public static final int SETTINGS_INVALID_SYNTAX = 1;
+    /** Error code indicating that the settings are invalid. */
     public static final int SETTINGS_INVALID = 2;
+    /** Error code indicating that a certificate could not be found. */
     public static final int CERT_NOT_FOUND = 3;
+    /** Error code indicating that a private key could not be found. */
     public static final int PRIVATE_KEY_NOT_FOUND = 4;
+    /** Error code indicating that the public certificate file could not be found. */
     public static final int PUBLIC_CERT_FILE_NOT_FOUND = 5;
+    /** Error code indicating that the private key file could not be found. */
     public static final int PRIVATE_KEY_FILE_NOT_FOUND = 6;
 
+    /** The error code identifying the specific settings problem. */
     private final int errorCode;
 
+    /**
+     * Constructs a new settings exception with the given message and error code.
+     *
+     * @param message the detail message describing the error
+     * @param errorCode the error code identifying the settings problem
+     */
     public SettingsException(final String message, final int errorCode) {
         super(message);
         this.errorCode = errorCode;
     }
 
+    /**
+     * Returns the error code identifying the specific settings problem.
+     *
+     * @return the error code
+     */
     public int getErrorCode() {
         return errorCode;
     }

--- a/core/src/main/java/org/codelibs/saml2/core/exception/ValidationException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/ValidationException.java
@@ -1,67 +1,133 @@
 package org.codelibs.saml2.core.exception;
 
+/**
+ * Exception thrown when SAML validation fails, carrying a specific error code.
+ */
 public class ValidationException extends SAMLException {
 
+    /** Serial version UID. */
     private static final long serialVersionUID = 1L;
 
+    /** Error code indicating an unsupported SAML version. */
     public static final int UNSUPPORTED_SAML_VERSION = 0;
+    /** Error code indicating a missing ID. */
     public static final int MISSING_ID = 1;
+    /** Error code indicating a wrong number of assertions. */
     public static final int WRONG_NUMBER_OF_ASSERTIONS = 2;
+    /** Error code indicating a missing status element. */
     public static final int MISSING_STATUS = 3;
+    /** Error code indicating a missing status code. */
     public static final int MISSING_STATUS_CODE = 4;
+    /** Error code indicating the status code is not success. */
     public static final int STATUS_CODE_IS_NOT_SUCCESS = 5;
+    /** Error code indicating a wrong signed element. */
     public static final int WRONG_SIGNED_ELEMENT = 6;
+    /** Error code indicating the ID was not found in the signed element. */
     public static final int ID_NOT_FOUND_IN_SIGNED_ELEMENT = 7;
+    /** Error code indicating a duplicated ID in the signed elements. */
     public static final int DUPLICATED_ID_IN_SIGNED_ELEMENTS = 8;
+    /** Error code indicating an invalid signed element. */
     public static final int INVALID_SIGNED_ELEMENT = 9;
+    /** Error code indicating a duplicated reference in the signed elements. */
     public static final int DUPLICATED_REFERENCE_IN_SIGNED_ELEMENTS = 10;
+    /** Error code indicating unexpected signed elements. */
     public static final int UNEXPECTED_SIGNED_ELEMENTS = 11;
+    /** Error code indicating a wrong number of signatures in the response. */
     public static final int WRONG_NUMBER_OF_SIGNATURES_IN_RESPONSE = 12;
+    /** Error code indicating a wrong number of signatures in the assertion. */
     public static final int WRONG_NUMBER_OF_SIGNATURES_IN_ASSERTION = 13;
+    /** Error code indicating an invalid XML format. */
     public static final int INVALID_XML_FORMAT = 14;
+    /** Error code indicating a wrong InResponseTo value. */
     public static final int WRONG_INRESPONSETO = 15;
+    /** Error code indicating no encrypted assertion was found. */
     public static final int NO_ENCRYPTED_ASSERTION = 16;
+    /** Error code indicating no encrypted NameID was found. */
     public static final int NO_ENCRYPTED_NAMEID = 17;
+    /** Error code indicating missing conditions. */
     public static final int MISSING_CONDITIONS = 18;
+    /** Error code indicating the assertion is not yet valid (too early). */
     public static final int ASSERTION_TOO_EARLY = 19;
+    /** Error code indicating the assertion has expired. */
     public static final int ASSERTION_EXPIRED = 20;
+    /** Error code indicating a wrong number of authentication statements. */
     public static final int WRONG_NUMBER_OF_AUTHSTATEMENTS = 21;
+    /** Error code indicating no attribute statement was found. */
     public static final int NO_ATTRIBUTESTATEMENT = 22;
+    /** Error code indicating encrypted attributes were found. */
     public static final int ENCRYPTED_ATTRIBUTES = 23;
+    /** Error code indicating a wrong destination. */
     public static final int WRONG_DESTINATION = 24;
+    /** Error code indicating an empty destination. */
     public static final int EMPTY_DESTINATION = 25;
+    /** Error code indicating a wrong audience. */
     public static final int WRONG_AUDIENCE = 26;
+    /** Error code indicating multiple issuers in the response. */
     public static final int ISSUER_MULTIPLE_IN_RESPONSE = 27;
+    /** Error code indicating the issuer was not found in the assertion. */
     public static final int ISSUER_NOT_FOUND_IN_ASSERTION = 28;
+    /** Error code indicating a wrong issuer. */
     public static final int WRONG_ISSUER = 29;
+    /** Error code indicating the session has expired. */
     public static final int SESSION_EXPIRED = 30;
+    /** Error code indicating a wrong subject confirmation. */
     public static final int WRONG_SUBJECTCONFIRMATION = 31;
+    /** Error code indicating no signed message was found. */
     public static final int NO_SIGNED_MESSAGE = 32;
+    /** Error code indicating no signed assertion was found. */
     public static final int NO_SIGNED_ASSERTION = 33;
+    /** Error code indicating no signature was found. */
     public static final int NO_SIGNATURE_FOUND = 34;
+    /** Error code indicating KeyInfo was not found in the encrypted data. */
     public static final int KEYINFO_NOT_FOUND_IN_ENCRYPTED_DATA = 35;
+    /** Error code indicating a children node was not found in KeyInfo. */
     public static final int CHILDREN_NODE_NOT_FOUND_IN_KEYINFO = 36;
+    /** Error code indicating an unsupported retrieval method. */
     public static final int UNSUPPORTED_RETRIEVAL_METHOD = 37;
+    /** Error code indicating no NameID was found. */
     public static final int NO_NAMEID = 38;
+    /** Error code indicating an empty NameID. */
     public static final int EMPTY_NAMEID = 39;
+    /** Error code indicating a mismatch in the SPNameQualifier of the NameID. */
     public static final int SP_NAME_QUALIFIER_NAME_MISMATCH = 40;
+    /** Error code indicating a duplicated attribute name was found. */
     public static final int DUPLICATED_ATTRIBUTE_NAME_FOUND = 41;
+    /** Error code indicating an invalid signature. */
     public static final int INVALID_SIGNATURE = 42;
+    /** Error code indicating a wrong number of signatures. */
     public static final int WRONG_NUMBER_OF_SIGNATURES = 43;
+    /** Error code indicating the response has expired. */
     public static final int RESPONSE_EXPIRED = 44;
+    /** Error code indicating an unexpected reference. */
     public static final int UNEXPECTED_REFERENCE = 45;
+    /** Error code indicating the operation is not supported. */
     public static final int NOT_SUPPORTED = 46;
+    /** Error code indicating a key algorithm error. */
     public static final int KEY_ALGORITHM_ERROR = 47;
+    /** Error code indicating a missing encrypted element. */
     public static final int MISSING_ENCRYPTED_ELEMENT = 48;
+    /** Error code indicating an invalid IssueInstant format. */
     public static final int INVALID_ISSUE_INSTANT_FORMAT = 49;
 
+    /** The error code associated with this validation failure. */
     private final int errorCode;
 
+    /**
+     * Constructs a new {@code ValidationException} with the given message and error code.
+     *
+     * @param message the detail message
+     * @param errorCode the error code identifying the validation failure
+     */
     public ValidationException(final String message, final int errorCode) {
         super(message);
         this.errorCode = errorCode;
     }
 
+    /**
+     * Returns the error code associated with this validation failure.
+     *
+     * @return the error code
+     */
     public int getErrorCode() {
         return errorCode;
     }

--- a/core/src/main/java/org/codelibs/saml2/core/exception/X509CertificateException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/X509CertificateException.java
@@ -2,10 +2,19 @@ package org.codelibs.saml2.core.exception;
 
 import java.security.cert.CertificateException;
 
+/**
+ * Exception thrown when an X.509 certificate cannot be processed.
+ */
 public class X509CertificateException extends SAMLException {
 
+    /** Serial version UID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new {@code X509CertificateException} wrapping the given certificate exception.
+     *
+     * @param e the underlying certificate exception
+     */
     public X509CertificateException(CertificateException e) {
         super(e);
     }

--- a/core/src/main/java/org/codelibs/saml2/core/exception/XMLParsingException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/XMLParsingException.java
@@ -1,9 +1,19 @@
 package org.codelibs.saml2.core.exception;
 
+/**
+ * Exception thrown when XML parsing fails.
+ */
 public class XMLParsingException extends SAMLException {
 
+    /** Serial version UID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new {@code XMLParsingException} with the given message and cause.
+     *
+     * @param message the detail message
+     * @param cause the underlying cause of the parsing failure
+     */
     public XMLParsingException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/core/src/main/java/org/codelibs/saml2/core/http/HttpRequest.java
+++ b/core/src/main/java/org/codelibs/saml2/core/http/HttpRequest.java
@@ -23,6 +23,7 @@ import org.codelibs.saml2.core.util.Util;
  */
 public final class HttpRequest {
 
+    /** An immutable empty map used as the default set of request parameters. */
     public static final Map<String, List<String>> EMPTY_PARAMETERS = Collections.<String, List<String>> emptyMap();
 
     private final String requestURL;
@@ -76,6 +77,8 @@ public final class HttpRequest {
     }
 
     /**
+     * Returns a copy of this request with the given query parameter added.
+     *
      * @param name  the query parameter name
      * @param value the query parameter value
      * @return a new HttpRequest with the given query parameter added
@@ -94,6 +97,8 @@ public final class HttpRequest {
     }
 
     /**
+     * Returns a copy of this request with the given query parameter removed.
+     *
      * @param name  the query parameter name
      * @return a new HttpRequest with the given query parameter removed
      */
@@ -117,6 +122,8 @@ public final class HttpRequest {
     }
 
     /**
+     * Returns the first value of the named query parameter.
+     *
      * @param name the query parameter name
      * @return the first value for the parameter, or null
      */
@@ -126,6 +133,8 @@ public final class HttpRequest {
     }
 
     /**
+     * Returns all values of the named query parameter.
+     *
      * @param name the query parameter name
      * @return a List containing all values for the parameter
      */
@@ -135,6 +144,8 @@ public final class HttpRequest {
     }
 
     /**
+     * Returns all query parameters of this request.
+     *
      * @return a map of all query parameters
      */
     public Map<String, List<String>> getParameters() {
@@ -146,7 +157,7 @@ public final class HttpRequest {
      * Prefer to extract the original encoded value directly from queryString since url
      * encoding is not canonical.
      *
-     * @param name
+     * @param name the query parameter name
      * @return the first value for the parameter, or null
      */
     public String getEncodedParameter(final String name) {
@@ -162,8 +173,8 @@ public final class HttpRequest {
      * Prefer to extract the original encoded value directly from queryString since url
      * encoding is not canonical.
      *
-     * @param name
-     * @param defaultValue
+     * @param name the query parameter name
+     * @param defaultValue the default value to return when the parameter is absent
      * @return the first value for the parameter, or url encoded default value
      */
     public String getEncodedParameter(final String name, final String defaultValue) {

--- a/core/src/main/java/org/codelibs/saml2/core/logout/LogoutRequest.java
+++ b/core/src/main/java/org/codelibs/saml2/core/logout/LogoutRequest.java
@@ -283,6 +283,8 @@ public class LogoutRequest {
     }
 
     /**
+     * Returns the base64 encoded unsigned Logout Request.
+     *
      * @return the base64 encoded unsigned Logout Request (deflated or not)
      *
      * @param deflated
@@ -303,6 +305,8 @@ public class LogoutRequest {
     }
 
     /**
+     * Returns the base64 encoded unsigned Logout Request.
+     *
      * @return the base64 encoded unsigned Logout Request (deflated or not)
      *
      */
@@ -311,6 +315,8 @@ public class LogoutRequest {
     }
 
     /**
+     * Returns the plain XML Logout Request.
+     *
      * @return the plain XML Logout Request
      */
     public String getLogoutRequestXml() {
@@ -994,6 +1000,8 @@ public class LogoutRequest {
     }
 
     /**
+     * Returns the ID of the Logout Request.
+     *
      * @return the ID of the Logout Request
      */
     public String getId() {

--- a/core/src/main/java/org/codelibs/saml2/core/logout/LogoutRequestParams.java
+++ b/core/src/main/java/org/codelibs/saml2/core/logout/LogoutRequestParams.java
@@ -118,6 +118,8 @@ public class LogoutRequestParams {
     }
 
     /**
+     * Returns the name ID.
+     *
      * @return the name ID
      */
     public String getNameId() {
@@ -125,6 +127,8 @@ public class LogoutRequestParams {
     }
 
     /**
+     * Returns the name ID format.
+     *
      * @return the name ID format
      */
     public String getNameIdFormat() {
@@ -132,6 +136,8 @@ public class LogoutRequestParams {
     }
 
     /**
+     * Returns the name ID name qualifier.
+     *
      * @return the name ID name qualifier
      */
     public String getNameIdNameQualifier() {
@@ -139,6 +145,8 @@ public class LogoutRequestParams {
     }
 
     /**
+     * Returns the name ID SP name qualifier.
+     *
      * @return the name ID SP name qualifier
      */
     public String getNameIdSPNameQualifier() {
@@ -146,6 +154,8 @@ public class LogoutRequestParams {
     }
 
     /**
+     * Returns the session index.
+     *
      * @return the session index
      */
     public String getSessionIndex() {

--- a/core/src/main/java/org/codelibs/saml2/core/logout/LogoutResponse.java
+++ b/core/src/main/java/org/codelibs/saml2/core/logout/LogoutResponse.java
@@ -123,6 +123,8 @@ public class LogoutResponse {
     }
 
     /**
+     * Returns the base64 encoded unsigned Logout Response.
+     *
      * @return the base64 encoded unsigned Logout Response (deflated or not)
      *
      * @param deflated
@@ -143,6 +145,8 @@ public class LogoutResponse {
     }
 
     /**
+     * Returns the base64 encoded, unsigned Logout Response.
+     *
      * @return the base64 encoded, unsigned Logout Response (deflated or not)
      *
      */
@@ -151,6 +155,8 @@ public class LogoutResponse {
     }
 
     /**
+     * Returns the plain XML Logout Response.
+     *
      * @return the plain XML Logout Response
      */
     public String getLogoutResponseXml() {
@@ -158,6 +164,8 @@ public class LogoutResponse {
     }
 
     /**
+     * Returns the ID of the Response.
+     *
      * @return the ID of the Response
      */
     public String getId() {
@@ -294,6 +302,11 @@ public class LogoutResponse {
         }
     }
 
+    /**
+     * Determines if the SAML LogoutResponse is valid, without checking a request ID.
+     *
+     * @return true if the LogoutResponse is valid
+     */
     public boolean isValid() {
         return isValid(null);
     }

--- a/core/src/main/java/org/codelibs/saml2/core/model/AttributeConsumingService.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/AttributeConsumingService.java
@@ -39,6 +39,8 @@ public class AttributeConsumingService {
     }
 
     /**
+     * Adds a requested attribute to this attribute consuming service.
+     *
      * @param attr
      *              RequestedAttribute. The requested attribute to be included
      */
@@ -47,6 +49,8 @@ public class AttributeConsumingService {
     }
 
     /**
+     * Returns the service name.
+     *
      * @return string the service name
      */
     public final String getServiceName() {
@@ -54,6 +58,8 @@ public class AttributeConsumingService {
     }
 
     /**
+     * Returns the service description.
+     *
      * @return string the service description
      */
     public final String getServiceDescription() {
@@ -61,6 +67,8 @@ public class AttributeConsumingService {
     }
 
     /**
+     * Returns the requested attributes.
+     *
      * @return List the requested attributes
      */
     public final List<RequestedAttribute> getRequestedAttributes() {

--- a/core/src/main/java/org/codelibs/saml2/core/model/Contact.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/Contact.java
@@ -86,6 +86,8 @@ public class Contact {
     }
 
     /**
+     * Returns the contact type.
+     *
      * @return string the contact type
      */
     public final String getContactType() {
@@ -93,6 +95,8 @@ public class Contact {
     }
 
     /**
+     * Returns the first contact e-mail address.
+     *
      * @return the contact email
      * @deprecated this returns just the first e-mail address in {@link #getEmailAddresses()}
      */
@@ -102,6 +106,8 @@ public class Contact {
     }
 
     /**
+     * Returns the contact e-mail addresses.
+     *
      * @return a list containing the contact e-mail addresses (never <code>null</code>)
      */
     public final List<String> getEmailAddresses() {
@@ -109,6 +115,8 @@ public class Contact {
     }
 
     /**
+     * Returns the contact given name.
+     *
      * @return the contact given name
      */
     public final String getGivenName() {
@@ -116,6 +124,8 @@ public class Contact {
     }
 
     /**
+     * Returns the contact surname.
+     *
      * @return the contact surname
      */
     public final String getSurName() {
@@ -123,6 +133,8 @@ public class Contact {
     }
 
     /**
+     * Returns the contact company.
+     *
      * @return the contact company
      */
     public final String getCompany() {
@@ -130,6 +142,8 @@ public class Contact {
     }
 
     /**
+     * Returns the contact phone numbers.
+     *
      * @return a list containing the contact phone numbers (never <code>null</code>)
      */
     public final List<String> getTelephoneNumbers() {

--- a/core/src/main/java/org/codelibs/saml2/core/model/KeyStoreSettings.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/KeyStoreSettings.java
@@ -42,6 +42,8 @@ public class KeyStoreSettings {
     }
 
     /**
+     * Returns the KeyStore.
+     *
      * @return the keyStore
      */
     public final KeyStore getKeyStore() {
@@ -49,6 +51,8 @@ public class KeyStoreSettings {
     }
 
     /**
+     * Returns the SP key entry alias.
+     *
      * @return the spAlias
      */
     public final String getSpAlias() {
@@ -56,6 +60,8 @@ public class KeyStoreSettings {
     }
 
     /**
+     * Returns the SP key entry password.
+     *
      * @return the spKeyPass
      */
     public final String getSpKeyPass() {

--- a/core/src/main/java/org/codelibs/saml2/core/model/Organization.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/Organization.java
@@ -96,6 +96,8 @@ public class Organization {
     }
 
     /**
+     * Returns the organization name.
+     *
      * @return string the organization name
      */
     public final String getOrgName() {
@@ -103,6 +105,8 @@ public class Organization {
     }
 
     /**
+     * Returns the organization display name.
+     *
      * @return string the organization display name
      */
     public final String getOrgDisplayName() {
@@ -110,6 +114,8 @@ public class Organization {
     }
 
     /**
+     * Returns the organization URL.
+     *
      * @return string the organization URL
      */
     public final String getOrgUrl() {
@@ -117,6 +123,8 @@ public class Organization {
     }
 
     /**
+     * Returns the organization lang attribute.
+     *
      * @return string the lang attribute
      */
     public final String getOrgLangAttribute() {

--- a/core/src/main/java/org/codelibs/saml2/core/model/RequestedAttribute.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/RequestedAttribute.java
@@ -57,6 +57,8 @@ public class RequestedAttribute {
     }
 
     /**
+     * Returns the RequestedAttribute name.
+     *
      * @return string the RequestedAttribute name
      */
     public final String getName() {
@@ -64,6 +66,8 @@ public class RequestedAttribute {
     }
 
     /**
+     * Returns the RequestedAttribute friendly name.
+     *
      * @return string the RequestedAttribute fiendlyname
      */
     public final String getFriendlyName() {
@@ -71,6 +75,8 @@ public class RequestedAttribute {
     }
 
     /**
+     * Returns whether the RequestedAttribute is required.
+     *
      * @return boolean the RequestedAttribute isRequired value
      */
     public final Boolean isRequired() {
@@ -78,6 +84,8 @@ public class RequestedAttribute {
     }
 
     /**
+     * Returns the RequestedAttribute name format.
+     *
      * @return string the RequestedAttribute nameformat
      */
     public final String getNameFormat() {
@@ -85,6 +93,8 @@ public class RequestedAttribute {
     }
 
     /**
+     * Returns the RequestedAttribute values.
+     *
      * @return string the RequestedAttribute nameformat
      */
     public final List<String> getAttributeValues() {

--- a/core/src/main/java/org/codelibs/saml2/core/model/SamlResponseStatus.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/SamlResponseStatus.java
@@ -45,6 +45,8 @@ public class SamlResponseStatus {
     }
 
     /**
+     * Returns the status code.
+     *
      * @return string the status code
      */
     public String getStatusCode() {
@@ -62,6 +64,8 @@ public class SamlResponseStatus {
     }
 
     /**
+     * Returns the second-level status code.
+     *
      * @return string the second-level status code
      */
     public String getSubStatusCode() {
@@ -79,6 +83,8 @@ public class SamlResponseStatus {
     }
 
     /**
+     * Returns the status message.
+     *
      * @return string the status message
      */
     public String getStatusMessage() {

--- a/core/src/main/java/org/codelibs/saml2/core/model/SubjectConfirmationIssue.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/SubjectConfirmationIssue.java
@@ -2,15 +2,30 @@ package org.codelibs.saml2.core.model;
 
 import java.util.List;
 
+/**
+ * Represents a validation issue found on a SubjectConfirmation element of a SAML Response.
+ */
 public class SubjectConfirmationIssue {
     private final int subjectConfirmationIndex;
     private final String message;
 
+    /**
+     * Constructor.
+     *
+     * @param subjectConfirmationIndex the index of the SubjectConfirmation element with the issue
+     * @param message                  the message describing the issue
+     */
     public SubjectConfirmationIssue(final int subjectConfirmationIndex, final String message) {
         this.subjectConfirmationIndex = subjectConfirmationIndex;
         this.message = message;
     }
 
+    /**
+     * Builds a human-readable message describing the given SubjectConfirmation issues.
+     *
+     * @param subjectConfirmationDataIssues the list of issues to describe
+     * @return a formatted message describing the issues
+     */
     public static String prettyPrintIssues(final List<SubjectConfirmationIssue> subjectConfirmationDataIssues) {
         final StringBuilder subjectConfirmationDataIssuesMsg =
                 new StringBuilder("A valid SubjectConfirmation was not found on this Response");

--- a/core/src/main/java/org/codelibs/saml2/core/model/hsm/AzureKeyVault.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/hsm/AzureKeyVault.java
@@ -13,6 +13,9 @@ import com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder;
 import com.azure.security.keyvault.keys.cryptography.models.EncryptionAlgorithm;
 import com.azure.security.keyvault.keys.cryptography.models.KeyWrapAlgorithm;
 
+/**
+ * HSM implementation backed by Azure Key Vault for cryptographic operations.
+ */
 public class AzureKeyVault extends HSM {
 
     private final String clientId;

--- a/core/src/main/java/org/codelibs/saml2/core/model/hsm/HSM.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/hsm/HSM.java
@@ -1,6 +1,19 @@
 package org.codelibs.saml2.core.model.hsm;
 
+/**
+ * Abstract base class for Hardware Security Module (HSM) integrations.
+ *
+ * Implementations provide key wrapping, unwrapping, encryption and decryption
+ * operations backed by an HSM such as the Azure Key Vault.
+ */
 public abstract class HSM {
+
+    /**
+     * Default constructor.
+     */
+    protected HSM() {
+    }
+
     /**
      * Sets the client to connect to the Azure Key Vault.
      */

--- a/core/src/main/java/org/codelibs/saml2/core/settings/IdPMetadataParser.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/IdPMetadataParser.java
@@ -33,6 +33,12 @@ public class IdPMetadataParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(IdPMetadataParser.class);
 
     /**
+     * Default constructor.
+     */
+    public IdPMetadataParser() {
+    }
+
+    /**
      * Get IdP Metadata Info from XML Document
      *
      * @param xmlDocument

--- a/core/src/main/java/org/codelibs/saml2/core/settings/Metadata.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/Metadata.java
@@ -380,6 +380,8 @@ public class Metadata {
     }
 
     /**
+     * Returns the metadata as a string.
+     *
      * @return the metadata
      */
     public final String getMetadataString() {

--- a/core/src/main/java/org/codelibs/saml2/core/settings/Saml2Settings.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/Saml2Settings.java
@@ -32,6 +32,13 @@ public class Saml2Settings {
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(Saml2Settings.class);
 
+    /**
+     * Constructs a new {@link Saml2Settings} instance with default values.
+     */
+    public Saml2Settings() {
+        // Default constructor; settings are populated via setter methods.
+    }
+
     // Toolkit settings
     private boolean strict = true;
     private boolean debug = false;
@@ -97,6 +104,8 @@ public class Saml2Settings {
     private boolean spValidationOnly = false;
 
     /**
+     * Returns whether strict mode is enabled.
+     *
      * @return the strict setting value
      */
     public final boolean isStrict() {
@@ -104,6 +113,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider entity ID.
+     *
      * @return the spEntityId setting value
      */
     public final String getSpEntityId() {
@@ -111,6 +122,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider Assertion Consumer Service URL.
+     *
      * @return the spAssertionConsumerServiceUrl
      */
     public final URL getSpAssertionConsumerServiceUrl() {
@@ -118,6 +131,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider Assertion Consumer Service binding.
+     *
      * @return the spAssertionConsumerServiceBinding setting value
      */
     public final String getSpAssertionConsumerServiceBinding() {
@@ -125,6 +140,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider Single Logout Service URL.
+     *
      * @return the spSingleLogoutServiceUrl setting value
      */
     public final URL getSpSingleLogoutServiceUrl() {
@@ -132,6 +149,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider Single Logout Service binding.
+     *
      * @return the spSingleLogoutServiceBinding setting value
      */
     public final String getSpSingleLogoutServiceBinding() {
@@ -139,6 +158,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider NameID format.
+     *
      * @return the spNameIDFormat setting value
      */
     public final String getSpNameIDFormat() {
@@ -146,6 +167,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether repeated attribute names are allowed.
+     *
      * @return the allowRepeatAttributeName setting value
      */
     public boolean isAllowRepeatAttributeName() {
@@ -153,6 +176,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether deprecated algorithms are rejected.
+     *
      * @return the rejectDeprecatedAlg setting value
      */
     public boolean getRejectDeprecatedAlg() {
@@ -160,6 +185,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider X.509 certificate.
+     *
      * @return the spX509cert setting value
      */
     public final X509Certificate getSPcert() {
@@ -167,6 +194,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the new Service Provider X.509 certificate used for certificate rollover.
+     *
      * @return the spX509certNew setting value
      */
     public final X509Certificate getSPcertNew() {
@@ -174,6 +203,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider private key.
+     *
      * @return the spPrivateKey setting value
      */
     public final PrivateKey getSPkey() {
@@ -181,6 +212,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Identity Provider entity ID.
+     *
      * @return the idpEntityId setting value
      */
     public final String getIdpEntityId() {
@@ -188,6 +221,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Identity Provider Single Sign-On Service URL.
+     *
      * @return the idpSingleSignOnServiceUrl setting value
      */
     public final URL getIdpSingleSignOnServiceUrl() {
@@ -195,6 +230,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Identity Provider Single Sign-On Service binding.
+     *
      * @return the idpSingleSignOnServiceBinding setting value
      */
     public final String getIdpSingleSignOnServiceBinding() {
@@ -202,6 +239,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Identity Provider Single Logout Service URL.
+     *
      * @return the idpSingleLogoutServiceUrl setting value
      */
     public final URL getIdpSingleLogoutServiceUrl() {
@@ -209,6 +248,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Identity Provider Single Logout Service response URL, falling back to the request URL if unset.
+     *
      * @return the idpSingleLogoutServiceResponseUrl setting value
      */
     public final URL getIdpSingleLogoutServiceResponseUrl() {
@@ -220,6 +261,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Identity Provider Single Logout Service binding.
+     *
      * @return the idpSingleLogoutServiceBinding setting value
      */
     public final String getIdpSingleLogoutServiceBinding() {
@@ -227,6 +270,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Identity Provider X.509 certificate.
+     *
      * @return the idpx509cert setting value
      */
     public final X509Certificate getIdpx509cert() {
@@ -258,6 +303,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the list of additional Identity Provider X.509 certificates.
+     *
      * @return the idpx509certMulti setting value
      */
     public List<X509Certificate> getIdpx509certMulti() {
@@ -265,6 +312,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether the NameID should be encrypted.
+     *
      * @return the nameIdEncrypted setting value
      */
     public boolean getNameIdEncrypted() {
@@ -272,6 +321,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether authentication requests should be signed.
+     *
      * @return the authnRequestsSigned setting value
      */
     public boolean getAuthnRequestsSigned() {
@@ -279,6 +330,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether logout requests should be signed.
+     *
      * @return the logoutRequestSigned setting value
      */
     public boolean getLogoutRequestSigned() {
@@ -286,6 +339,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether logout responses should be signed.
+     *
      * @return the logoutResponseSigned setting value
      */
     public boolean getLogoutResponseSigned() {
@@ -293,6 +348,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether SAML messages are expected to be signed.
+     *
      * @return the wantMessagesSigned setting value
      */
     public boolean getWantMessagesSigned() {
@@ -300,6 +357,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether SAML assertions are expected to be signed.
+     *
      * @return the wantAssertionsSigned setting value
      */
     public boolean getWantAssertionsSigned() {
@@ -307,6 +366,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether SAML assertions are expected to be encrypted.
+     *
      * @return the wantAssertionsEncrypted setting value
      */
     public boolean getWantAssertionsEncrypted() {
@@ -314,6 +375,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether a NameID is expected in the SAML response.
+     *
      * @return the wantNameId setting value
      */
     public boolean getWantNameId() {
@@ -321,6 +384,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether the NameID is expected to be encrypted.
+     *
      * @return the wantNameIdEncrypted setting value
      */
     public boolean getWantNameIdEncrypted() {
@@ -328,6 +393,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether the Service Provider metadata should be signed.
+     *
      * @return the signMetadata setting value
      */
     public boolean getSignMetadata() {
@@ -335,6 +402,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the requested authentication context values.
+     *
      * @return the requestedAuthnContext setting value
      */
     public List<String> getRequestedAuthnContext() {
@@ -342,6 +411,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the requested authentication context comparison method.
+     *
      * @return the requestedAuthnContextComparison setting value
      */
     public String getRequestedAuthnContextComparison() {
@@ -349,6 +420,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether XML schema validation is performed on SAML messages.
+     *
      * @return the wantXMLValidation setting value
      */
     public boolean getWantXMLValidation() {
@@ -356,6 +429,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the signature algorithm used for signing.
+     *
      * @return the signatureAlgorithm setting value
      */
     public String getSignatureAlgorithm() {
@@ -363,6 +438,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the digest algorithm used for signing.
+     *
      * @return the digestAlgorithm setting value
      */
     public String getDigestAlgorithm() {
@@ -370,6 +447,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider contact information.
+     *
      * @return SP Contact info
      */
     public List<Contact> getContacts() {
@@ -377,6 +456,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Service Provider organization information.
+     *
      * @return SP Organization info
      */
     public Organization getOrganization() {
@@ -384,6 +465,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the prefix used when generating unique IDs.
+     *
      * @return Unique ID prefix
      */
     public String getUniqueIDPrefix() {
@@ -391,6 +474,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the Hardware Security Module configuration.
+     *
      * @return The HSM setting value.
      */
     public HSM getHsm() {
@@ -398,6 +483,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether debug mode is active.
+     *
      * @return if the debug is active or not
      */
     public boolean isDebugActive() {
@@ -405,6 +492,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the allowed clock drift in seconds.
+     *
      * @return the clock drift in seconds
      */
     public long getClockDrift() {
@@ -850,6 +939,11 @@ public class Saml2Settings {
         this.rejectUnsolicitedResponsesWithInResponseTo = rejectUnsolicitedResponsesWithInResponseTo;
     }
 
+    /**
+     * Returns whether unsolicited Responses containing an InResponseTo value are rejected.
+     *
+     * @return the rejectUnsolicitedResponsesWithInResponseTo setting value
+     */
     public boolean isRejectUnsolicitedResponsesWithInResponseTo() {
         return rejectUnsolicitedResponsesWithInResponseTo;
     }
@@ -865,6 +959,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether request compression is enabled.
+     *
      * @return the compressRequest setting value
      */
     public boolean isCompressRequestEnabled() {
@@ -882,6 +978,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether response compression is enabled.
+     *
      * @return the compressResponse setting value
      */
     public boolean isCompressResponseEnabled() {
@@ -1138,6 +1236,8 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns whether only Service Provider settings are validated.
+     *
      * @return the spValidationOnly value
      */
     public boolean getSPValidationOnly() {

--- a/core/src/main/java/org/codelibs/saml2/core/settings/SettingsBuilder.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/SettingsBuilder.java
@@ -45,6 +45,12 @@ import org.slf4j.LoggerFactory;
  */
 public class SettingsBuilder {
     /**
+     * Default constructor.
+     */
+    public SettingsBuilder() {
+    }
+
+    /**
      * Private property to construct a logger for this class.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(SettingsBuilder.class);
@@ -59,92 +65,170 @@ public class SettingsBuilder {
      */
     private Saml2Settings saml2Setting;
 
+    /** Property key for the strict mode flag ({@code onelogin.saml2.strict}). */
     public final static String STRICT_PROPERTY_KEY = "onelogin.saml2.strict";
+    /** Property key for the debug mode flag ({@code onelogin.saml2.debug}). */
     public final static String DEBUG_PROPERTY_KEY = "onelogin.saml2.debug";
 
     // SP
+    /** Property key for the SP entity ID ({@code onelogin.saml2.sp.entityid}). */
     public final static String SP_ENTITYID_PROPERTY_KEY = "onelogin.saml2.sp.entityid";
+    /** Property key for the SP Assertion Consumer Service URL ({@code onelogin.saml2.sp.assertion_consumer_service.url}). */
     public final static String SP_ASSERTION_CONSUMER_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.sp.assertion_consumer_service.url";
+    /** Property key for the SP Assertion Consumer Service binding ({@code onelogin.saml2.sp.assertion_consumer_service.binding}). */
     public final static String SP_ASSERTION_CONSUMER_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.sp.assertion_consumer_service.binding";
+    /** Property key for the SP Single Logout Service URL ({@code onelogin.saml2.sp.single_logout_service.url}). */
     public final static String SP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.sp.single_logout_service.url";
+    /** Property key for the SP Single Logout Service binding ({@code onelogin.saml2.sp.single_logout_service.binding}). */
     public final static String SP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.sp.single_logout_service.binding";
+    /** Property key for the SP NameID format ({@code onelogin.saml2.sp.nameidformat}). */
     public final static String SP_NAMEIDFORMAT_PROPERTY_KEY = "onelogin.saml2.sp.nameidformat";
 
+    /** Property key for the SP X.509 certificate ({@code onelogin.saml2.sp.x509cert}). */
     public final static String SP_X509CERT_PROPERTY_KEY = "onelogin.saml2.sp.x509cert";
+    /** Property key for the SP private key ({@code onelogin.saml2.sp.privatekey}). */
     public final static String SP_PRIVATEKEY_PROPERTY_KEY = "onelogin.saml2.sp.privatekey";
+    /** Property key for the SP new X.509 certificate used during certificate rotation ({@code onelogin.saml2.sp.x509certNew}). */
     public final static String SP_X509CERTNEW_PROPERTY_KEY = "onelogin.saml2.sp.x509certNew";
 
+    /** Property key prefix for SP contact entries ({@code onelogin.saml2.sp.contact}). */
     public final static String SP_CONTACT_PROPERTY_KEY_PREFIX = "onelogin.saml2.sp.contact";
+    /** Property key suffix for the SP contact type ({@code contactType}). */
     public final static String SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX = "contactType";
+    /** Property key suffix for the SP contact company name ({@code company}). */
     public final static String SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX = "company";
+    /** Property key suffix for the SP contact given name ({@code given_name}). */
     public final static String SP_CONTACT_GIVEN_NAME_PROPERTY_KEY_SUFFIX = "given_name";
+    /** Property key suffix for the SP contact surname ({@code sur_name}). */
     public final static String SP_CONTACT_SUR_NAME_PROPERTY_KEY_SUFFIX = "sur_name";
+    /** Property key prefix for the SP contact e-mail addresses ({@code email_address}). */
     public final static String SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX = "email_address";
+    /** Property key prefix for the SP contact telephone numbers ({@code telephone_number}). */
     public final static String SP_CONTACT_TELEPHONE_NUMBER_PROPERTY_KEY_PREFIX = "telephone_number";
 
     // KeyStore
+    /** Property key for the KeyStore instance holding the SP keys ({@code onelogin.saml2.keystore.store}). */
     public final static String KEYSTORE_KEY = "onelogin.saml2.keystore.store";
+    /** Property key for the KeyStore alias of the SP entry ({@code onelogin.saml2.keystore.alias}). */
     public final static String KEYSTORE_ALIAS = "onelogin.saml2.keystore.alias";
+    /** Property key for the KeyStore key password ({@code onelogin.saml2.keystore.key.password}). */
     public final static String KEYSTORE_KEY_PASSWORD = "onelogin.saml2.keystore.key.password";
 
     // IDP
+    /** Property key for the IdP entity ID ({@code onelogin.saml2.idp.entityid}). */
     public final static String IDP_ENTITYID_PROPERTY_KEY = "onelogin.saml2.idp.entityid";
+    /** Property key for the IdP Single Sign-On Service URL ({@code onelogin.saml2.idp.single_sign_on_service.url}). */
     public final static String IDP_SINGLE_SIGN_ON_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.idp.single_sign_on_service.url";
+    /** Property key for the IdP Single Sign-On Service binding ({@code onelogin.saml2.idp.single_sign_on_service.binding}). */
     public final static String IDP_SINGLE_SIGN_ON_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.idp.single_sign_on_service.binding";
+    /** Property key for the IdP Single Logout Service URL ({@code onelogin.saml2.idp.single_logout_service.url}). */
     public final static String IDP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.idp.single_logout_service.url";
+    /** Property key for the IdP Single Logout Service response URL ({@code onelogin.saml2.idp.single_logout_service.response.url}). */
     public final static String IDP_SINGLE_LOGOUT_SERVICE_RESPONSE_URL_PROPERTY_KEY =
             "onelogin.saml2.idp.single_logout_service.response.url";
+    /** Property key for the IdP Single Logout Service binding ({@code onelogin.saml2.idp.single_logout_service.binding}). */
     public final static String IDP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.idp.single_logout_service.binding";
 
+    /** Property key for the IdP X.509 certificate ({@code onelogin.saml2.idp.x509cert}). */
     public final static String IDP_X509CERT_PROPERTY_KEY = "onelogin.saml2.idp.x509cert";
+    /** Property key prefix for multiple IdP X.509 certificates ({@code onelogin.saml2.idp.x509certMulti}). */
     public final static String IDP_X509CERTMULTI_PROPERTY_KEY = "onelogin.saml2.idp.x509certMulti";
+    /** Property key for the IdP certificate fingerprint ({@code onelogin.saml2.idp.certfingerprint}). */
     public final static String CERTFINGERPRINT_PROPERTY_KEY = "onelogin.saml2.idp.certfingerprint";
+    /** Property key for the IdP certificate fingerprint algorithm ({@code onelogin.saml2.idp.certfingerprint_algorithm}). */
     public final static String CERTFINGERPRINT_ALGORITHM_PROPERTY_KEY = "onelogin.saml2.idp.certfingerprint_algorithm";
 
     // Security
+    /** Property key controlling whether the NameID is encrypted ({@code onelogin.saml2.security.nameid_encrypted}). */
     public final static String SECURITY_NAMEID_ENCRYPTED = "onelogin.saml2.security.nameid_encrypted";
+    /** Property key controlling whether AuthnRequests are signed ({@code onelogin.saml2.security.authnrequest_signed}). */
     public final static String SECURITY_AUTHREQUEST_SIGNED = "onelogin.saml2.security.authnrequest_signed";
+    /** Property key controlling whether LogoutRequests are signed ({@code onelogin.saml2.security.logoutrequest_signed}). */
     public final static String SECURITY_LOGOUTREQUEST_SIGNED = "onelogin.saml2.security.logoutrequest_signed";
+    /** Property key controlling whether LogoutResponses are signed ({@code onelogin.saml2.security.logoutresponse_signed}). */
     public final static String SECURITY_LOGOUTRESPONSE_SIGNED = "onelogin.saml2.security.logoutresponse_signed";
+    /** Property key controlling whether received messages must be signed ({@code onelogin.saml2.security.want_messages_signed}). */
     public final static String SECURITY_WANT_MESSAGES_SIGNED = "onelogin.saml2.security.want_messages_signed";
+    /** Property key controlling whether received assertions must be signed ({@code onelogin.saml2.security.want_assertions_signed}). */
     public final static String SECURITY_WANT_ASSERTIONS_SIGNED = "onelogin.saml2.security.want_assertions_signed";
+    /** Property key controlling whether received assertions must be encrypted ({@code onelogin.saml2.security.want_assertions_encrypted}). */
     public final static String SECURITY_WANT_ASSERTIONS_ENCRYPTED = "onelogin.saml2.security.want_assertions_encrypted";
+    /** Property key controlling whether a NameID is required in responses ({@code onelogin.saml2.security.want_nameid}). */
     public final static String SECURITY_WANT_NAMEID = "onelogin.saml2.security.want_nameid";
+    /** Property key controlling whether the received NameID must be encrypted ({@code onelogin.saml2.security.want_nameid_encrypted}). */
     public final static String SECURITY_WANT_NAMEID_ENCRYPTED = "onelogin.saml2.security.want_nameid_encrypted";
+    /** Property key controlling whether the SP metadata is signed ({@code onelogin.saml2.security.sign_metadata}). */
     public final static String SECURITY_SIGN_METADATA = "onelogin.saml2.security.sign_metadata";
+    /** Property key for the requested authentication context(s) ({@code onelogin.saml2.security.requested_authncontext}). */
     public final static String SECURITY_REQUESTED_AUTHNCONTEXT = "onelogin.saml2.security.requested_authncontext";
+    /** Property key for the requested authentication context comparison ({@code onelogin.saml2.security.requested_authncontextcomparison}). */
     public final static String SECURITY_REQUESTED_AUTHNCONTEXTCOMPARISON = "onelogin.saml2.security.requested_authncontextcomparison";
+    /** Property key controlling whether XML schema validation is performed ({@code onelogin.saml2.security.want_xml_validation}). */
     public final static String SECURITY_WANT_XML_VALIDATION = "onelogin.saml2.security.want_xml_validation";
+    /** Property key for the signature algorithm used when signing ({@code onelogin.saml2.security.signature_algorithm}). */
     public final static String SECURITY_SIGNATURE_ALGORITHM = "onelogin.saml2.security.signature_algorithm";
+    /** Property key for the digest algorithm used when signing ({@code onelogin.saml2.security.digest_algorithm}). */
     public final static String SECURITY_DIGEST_ALGORITHM = "onelogin.saml2.security.digest_algorithm";
+    /** Property key controlling whether unsolicited responses with an InResponseTo attribute are rejected ({@code onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto}). */
     public final static String SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO =
             "onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto";
+    /** Property key controlling whether duplicated attribute names are allowed ({@code onelogin.saml2.security.allow_duplicated_attribute_name}). */
     public final static String SECURITY_ALLOW_REPEAT_ATTRIBUTE_NAME_PROPERTY_KEY =
             "onelogin.saml2.security.allow_duplicated_attribute_name";
+    /** Property key controlling whether deprecated cryptographic algorithms are rejected ({@code onelogin.saml2.security.reject_deprecated_alg}). */
     public final static String SECURITY_REJECT_DEPRECATED_ALGORITHM = "onelogin.saml2.security.reject_deprecated_alg";
 
     // Compress
+    /** Property key controlling whether outgoing requests are compressed ({@code onelogin.saml2.compress.request}). */
     public final static String COMPRESS_REQUEST = "onelogin.saml2.compress.request";
+    /** Property key controlling whether outgoing responses are compressed ({@code onelogin.saml2.compress.response}). */
     public final static String COMPRESS_RESPONSE = "onelogin.saml2.compress.response";
 
     // Parsing
+    /** Property key controlling whether NameID values are trimmed during parsing ({@code onelogin.saml2.parsing.trim_name_ids}). */
     public final static String PARSING_TRIM_NAME_IDS = "onelogin.saml2.parsing.trim_name_ids";
+    /** Property key controlling whether attribute values are trimmed during parsing ({@code onelogin.saml2.parsing.trim_attribute_values}). */
     public final static String PARSING_TRIM_ATTRIBUTE_VALUES = "onelogin.saml2.parsing.trim_attribute_values";
 
     // Misc
+    /**
+     * Property key for the legacy technical contact given name ({@code onelogin.saml2.contacts.technical.given_name}).
+     *
+     * @deprecated use the indexed {@code onelogin.saml2.sp.contact} properties instead
+     */
     @Deprecated
     public final static String CONTACT_TECHNICAL_GIVEN_NAME = "onelogin.saml2.contacts.technical.given_name";
+    /**
+     * Property key for the legacy technical contact e-mail address ({@code onelogin.saml2.contacts.technical.email_address}).
+     *
+     * @deprecated use the indexed {@code onelogin.saml2.sp.contact} properties instead
+     */
     @Deprecated
     public final static String CONTACT_TECHNICAL_EMAIL_ADDRESS = "onelogin.saml2.contacts.technical.email_address";
+    /**
+     * Property key for the legacy support contact given name ({@code onelogin.saml2.contacts.support.given_name}).
+     *
+     * @deprecated use the indexed {@code onelogin.saml2.sp.contact} properties instead
+     */
     @Deprecated
     public final static String CONTACT_SUPPORT_GIVEN_NAME = "onelogin.saml2.contacts.support.given_name";
+    /**
+     * Property key for the legacy support contact e-mail address ({@code onelogin.saml2.contacts.support.email_address}).
+     *
+     * @deprecated use the indexed {@code onelogin.saml2.sp.contact} properties instead
+     */
     @Deprecated
     public final static String CONTACT_SUPPORT_EMAIL_ADDRESS = "onelogin.saml2.contacts.support.email_address";
 
+    /** Property key for the organization name ({@code onelogin.saml2.organization.name}). */
     public final static String ORGANIZATION_NAME = "onelogin.saml2.organization.name";
+    /** Property key for the organization display name ({@code onelogin.saml2.organization.displayname}). */
     public final static String ORGANIZATION_DISPLAYNAME = "onelogin.saml2.organization.displayname";
+    /** Property key for the organization URL ({@code onelogin.saml2.organization.url}). */
     public final static String ORGANIZATION_URL = "onelogin.saml2.organization.url";
+    /** Property key for the organization language ({@code onelogin.saml2.organization.lang}). */
     public final static String ORGANIZATION_LANG = "onelogin.saml2.organization.lang";
+    /** Property key for the prefix used to generate unique IDs ({@code onelogin.saml2.unique_id_prefix}). */
     public final static String UNIQUE_ID_PREFIX_PROPERTY_KEY = "onelogin.saml2.unique_id_prefix";
 
     /**
@@ -868,6 +952,15 @@ public class SettingsBuilder {
         return null;
     }
 
+    /**
+     * Retrieves the PrivateKey associated with the given alias from the provided KeyStore.
+     *
+     * @param keyStore the KeyStore to read the private key from
+     * @param alias the alias of the entry whose private key is returned
+     * @param password the password used to access the key entry
+     *
+     * @return the PrivateKey for the alias, or {@code null} if it cannot be loaded
+     */
     protected PrivateKey getPrivateKeyFromKeyStore(final KeyStore keyStore, final String alias, final String password) {
         Key key;
         try {
@@ -885,6 +978,15 @@ public class SettingsBuilder {
         return null;
     }
 
+    /**
+     * Retrieves the X509Certificate associated with the given alias from the provided KeyStore.
+     *
+     * @param keyStore the KeyStore to read the certificate from
+     * @param alias the alias of the entry whose certificate is returned
+     * @param password the password used to access the key entry
+     *
+     * @return the X509Certificate for the alias, or {@code null} if it cannot be loaded
+     */
     protected X509Certificate getCertificateFromKeyStore(final KeyStore keyStore, final String alias, final String password) {
         try {
             if (keyStore.containsAlias(alias)) {

--- a/core/src/main/java/org/codelibs/saml2/core/util/Constants.java
+++ b/core/src/main/java/org/codelibs/saml2/core/util/Constants.java
@@ -24,118 +24,204 @@ public final class Constants {
     public static final long ALOWED_CLOCK_DRIFT = ALLOWED_CLOCK_DRIFT;
 
     // NameID Formats
+    /** SAML 1.1 email address NameID format URN. */
     public static final String NAMEID_EMAIL_ADDRESS = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+    /** SAML 1.1 X.509 subject name NameID format URN. */
     public static final String NAMEID_X509_SUBJECT_NAME = "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName";
+    /** SAML 1.1 Windows domain qualified name NameID format URN. */
     public static final String NAMEID_WINDOWS_DOMAIN_QUALIFIED_NAME =
             "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName";
+    /** SAML 1.1 unspecified NameID format URN. */
     public static final String NAMEID_UNSPECIFIED = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+    /** SAML 2.0 Kerberos principal name NameID format URN. */
     public static final String NAMEID_KERBEROS = "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos";
+    /** SAML 2.0 entity identifier NameID format URN. */
     public static final String NAMEID_ENTITY = "urn:oasis:names:tc:SAML:2.0:nameid-format:entity";
+    /** SAML 2.0 transient NameID format URN. */
     public static final String NAMEID_TRANSIENT = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient";
+    /** SAML 2.0 persistent NameID format URN. */
     public static final String NAMEID_PERSISTENT = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
+    /** SAML 2.0 encrypted NameID format URN. */
     public static final String NAMEID_ENCRYPTED = "urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted";
 
     // Attribute Name Formats
+    /** SAML 2.0 unspecified attribute name format URN. */
     public static final String ATTRNAME_FORMAT_UNSPECIFIED = "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified";
+    /** SAML 2.0 URI reference attribute name format URN. */
     public static final String ATTRNAME_FORMAT_URI = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
+    /** SAML 2.0 basic attribute name format URN. */
     public static final String ATTRNAME_FORMAT_BASIC = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic";
 
     // Namespaces
+    /** XML namespace URI for SAML 2.0 assertions. */
     public static final String NS_SAML = "urn:oasis:names:tc:SAML:2.0:assertion";
+    /** XML namespace URI for the SAML 2.0 protocol. */
     public static final String NS_SAMLP = "urn:oasis:names:tc:SAML:2.0:protocol";
+    /** XML namespace URI for the SOAP envelope. */
     public static final String NS_SOAP = "http://schemas.xmlsoap.org/soap/envelope/";
+    /** XML namespace URI for SAML 2.0 metadata. */
     public static final String NS_MD = "urn:oasis:names:tc:SAML:2.0:metadata";
+    /** XML namespace URI for XML Schema. */
     public static final String NS_XS = "http://www.w3.org/2001/XMLSchema";
+    /** XML namespace URI for XML Schema instances. */
     public static final String NS_XSI = "http://www.w3.org/2001/XMLSchema-instance";
+    /** XML namespace URI for XML Encryption. */
     public static final String NS_XENC = "http://www.w3.org/2001/04/xmlenc#";
+    /** XML namespace URI for XML Digital Signature. */
     public static final String NS_DS = "http://www.w3.org/2000/09/xmldsig#";
 
     // Bindings
+    /** SAML 2.0 HTTP-POST binding URN. */
     public static final String BINDING_HTTP_POST = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
+    /** SAML 2.0 HTTP-Redirect binding URN. */
     public static final String BINDING_HTTP_REDIRECT = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
+    /** SAML 2.0 HTTP-Artifact binding URN. */
     public static final String BINDING_HTTP_ARTIFACT = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact";
+    /** SAML 2.0 SOAP binding URN. */
     public static final String BINDING_SOAP = "urn:oasis:names:tc:SAML:2.0:bindings:SOAP";
+    /** SAML 2.0 DEFLATE URL-encoding binding URN. */
     public static final String BINDING_DEFLATE = "urn:oasis:names:tc:SAML:2.0:bindings:URL-Encoding:DEFLATE";
 
     // Auth Context Class
+    /** SAML 2.0 unspecified authentication context class URN. */
     public static final String AC_UNSPECIFIED = "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified";
+    /** SAML 2.0 password authentication context class URN. */
     public static final String AC_PASSWORD = "urn:oasis:names:tc:SAML:2.0:ac:classes:Password";
+    /** SAML 2.0 X.509 certificate authentication context class URN. */
     public static final String AC_X509 = "urn:oasis:names:tc:SAML:2.0:ac:classes:X509";
+    /** SAML 2.0 smart card authentication context class URN. */
     public static final String AC_SMARTCARD = "urn:oasis:names:tc:SAML:2.0:ac:classes:Smartcard";
+    /** SAML 2.0 Kerberos authentication context class URN. */
     public static final String AC_KERBEROS = "urn:oasis:names:tc:SAML:2.0:ac:classes:Kerberos";
 
     // Subject Confirmation
+    /** SAML 2.0 bearer subject confirmation method URN. */
     public static final String CM_BEARER = "urn:oasis:names:tc:SAML:2.0:cm:bearer";
+    /** SAML 2.0 holder-of-key subject confirmation method URN. */
     public static final String CM_HOLDER_KEY = "urn:oasis:names:tc:SAML:2.0:cm:holder-of-key";
+    /** SAML 2.0 sender-vouches subject confirmation method URN. */
     public static final String CM_SENDER_VOUCHES = "urn:oasis:names:tc:SAML:2.0:cm:sender-vouches";
 
     // Status Codes
+    /** SAML 2.0 top-level status code indicating success. */
     public static final String STATUS_SUCCESS = "urn:oasis:names:tc:SAML:2.0:status:Success";
+    /** SAML 2.0 top-level status code indicating an error caused by the requester. */
     public static final String STATUS_REQUESTER = "urn:oasis:names:tc:SAML:2.0:status:Requester";
+    /** SAML 2.0 top-level status code indicating an error caused by the responder. */
     public static final String STATUS_RESPONDER = "urn:oasis:names:tc:SAML:2.0:status:Responder";
+    /** SAML 2.0 top-level status code indicating a SAML version mismatch. */
     public static final String STATUS_VERSION_MISMATCH = "urn:oasis:names:tc:SAML:2.0:status:VersionMismatch";
 
     // Status Second-level Codes
+    /** SAML 2.0 second-level status code indicating authentication failure. */
     public static final String STATUS_AUTHNFAILED = "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed";
+    /** SAML 2.0 second-level status code indicating an invalid attribute name or value. */
     public static final String STATUS_INVALID_ATTRNAME_OR_VALUE = "urn:oasis:names:tc:SAML:2.0:status:InvalidAttrNameOrValue";
+    /** SAML 2.0 second-level status code indicating an invalid NameID policy. */
     public static final String STATUS_INVALID_NAMEIDPOLICY = "urn:oasis:names:tc:SAML:2.0:status:InvalidNameIDPolicy";
+    /** SAML 2.0 second-level status code indicating no matching authentication context. */
     public static final String STATUS_NO_AUTHNCONTEXT = "urn:oasis:names:tc:SAML:2.0:status:NoAuthnContext";
+    /** SAML 2.0 second-level status code indicating no available identity provider. */
     public static final String STATUS_NO_AVAILABLE_IDP = "urn:oasis:names:tc:SAML:2.0:status:NoAvailableIDP";
+    /** SAML 2.0 second-level status code indicating passive authentication was not possible. */
     public static final String STATUS_NO_PASSIVE = "urn:oasis:names:tc:SAML:2.0:status:NoPassive";
+    /** SAML 2.0 second-level status code indicating no supported identity provider. */
     public static final String STATUS_NO_SUPPORTED_IDP = "urn:oasis:names:tc:SAML:2.0:status:NoSupportedIDP";
+    /** SAML 2.0 second-level status code indicating a partial logout. */
     public static final String STATUS_PARTIAL_LOGOUT = "urn:oasis:names:tc:SAML:2.0:status:PartialLogout";
+    /** SAML 2.0 second-level status code indicating the proxy count was exceeded. */
     public static final String STATUS_PROXY_COUNT_EXCEEDED = "urn:oasis:names:tc:SAML:2.0:status:ProxyCountExceeded";
+    /** SAML 2.0 second-level status code indicating the request was denied. */
     public static final String STATUS_REQUEST_DENIED = "urn:oasis:names:tc:SAML:2.0:status:RequestDenied";
+    /** SAML 2.0 second-level status code indicating the request is unsupported. */
     public static final String STATUS_REQUEST_UNSUPPORTED = "urn:oasis:names:tc:SAML:2.0:status:RequestUnsupported";
+    /** SAML 2.0 second-level status code indicating the request version is deprecated. */
     public static final String STATUS_REQUEST_VERSION_DEPRECATED = "urn:oasis:names:tc:SAML:2.0:status:RequestVersionDeprecated";
+    /** SAML 2.0 second-level status code indicating the request version is too high. */
     public static final String STATUS_REQUEST_VERSION_TOO_HIGH = "urn:oasis:names:tc:SAML:2.0:status:RequestVersionTooHigh";
+    /** SAML 2.0 second-level status code indicating the request version is too low. */
     public static final String STATUS_REQUEST_VERSION_TOO_LOW = "urn:oasis:names:tc:SAML:2.0:status:RequestVersionTooLow";
+    /** SAML 2.0 second-level status code indicating the resource was not recognized. */
     public static final String STATUS_RESOURCE_NOT_RECOGNIZED = "urn:oasis:names:tc:SAML:2.0:status:ResourceNotRecognized";
+    /** SAML 2.0 second-level status code indicating too many responses. */
     public static final String STATUS_TOO_MANY_RESPONSES = "urn:oasis:names:tc:SAML:2.0:status:TooManyResponses";
+    /** SAML 2.0 second-level status code indicating an unknown attribute profile. */
     public static final String STATUS_UNKNOWN_ATTR_PROFILE = "urn:oasis:names:tc:SAML:2.0:status:UnknownAttrProfile";
+    /** SAML 2.0 second-level status code indicating an unknown principal. */
     public static final String STATUS_UNKNOWN_PRINCIPAL = "urn:oasis:names:tc:SAML:2.0:status:UnknownPrincipal";
+    /** SAML 2.0 second-level status code indicating an unsupported binding. */
     public static final String STATUS_UNSUPPORTED_BINDING = "urn:oasis:names:tc:SAML:2.0:status:UnsupportedBinding";
 
     // Contact types
+    /** Metadata contact type for technical contacts. */
     public static final String CONTACT_TYPE_TECHNICAL = "technical";
+    /** Metadata contact type for support contacts. */
     public static final String CONTACT_TYPE_SUPPORT = "support";
+    /** Metadata contact type for administrative contacts. */
     public static final String CONTACT_TYPE_ADMINISTRATIVE = "administrative";
+    /** Metadata contact type for billing contacts. */
     public static final String CONTACT_TYPE_BILLING = "billing";
+    /** Metadata contact type for other contacts. */
     public static final String CONTACT_TYPE_OTHER = "other";
 
     // Canonization
+    /** Exclusive XML canonicalization 1.0 algorithm URI (without comments). */
     public static final String C14N = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+    /** Inclusive XML canonicalization 1.0 algorithm URI with comments. */
     public static final String C14N_WC = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+    /** Inclusive XML canonicalization 1.1 algorithm URI (without comments). */
     public static final String C14N11 = "http://www.w3.org/2006/12/xml-c14n11";
+    /** Inclusive XML canonicalization 1.1 algorithm URI with comments. */
     public static final String C14N11_WC = "http://www.w3.org/2006/12/xml-c14n11#WithComments";
+    /** Exclusive XML canonicalization algorithm URI (without comments). */
     public static final String C14NEXC = "http://www.w3.org/2001/10/xml-exc-c14n#";
+    /** Exclusive XML canonicalization algorithm URI with comments. */
     public static final String C14NEXC_WC = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
 
     // Sign & Crypt
     // https://www.w3.org/TR/xmlenc-core/#sec-Alg-MessageDigest
     // https://www.w3.org/TR/xmlsec-algorithms/#signature-method-uris
     // https://tools.ietf.org/html/rfc6931
+    /** SHA-1 digest algorithm URI. */
     public static final String SHA1 = "http://www.w3.org/2000/09/xmldsig#sha1";
+    /** SHA-256 digest algorithm URI. */
     public static final String SHA256 = "http://www.w3.org/2001/04/xmlenc#sha256";
+    /** SHA-384 digest algorithm URI. */
     public static final String SHA384 = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+    /** SHA-512 digest algorithm URI. */
     public static final String SHA512 = "http://www.w3.org/2001/04/xmlenc#sha512";
 
+    /** DSA with SHA-1 signature algorithm URI. */
     public static final String DSA_SHA1 = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+    /** RSA with SHA-1 signature algorithm URI. */
     public static final String RSA_SHA1 = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+    /** RSA with SHA-256 signature algorithm URI. */
     public static final String RSA_SHA256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+    /** RSA with SHA-384 signature algorithm URI. */
     public static final String RSA_SHA384 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+    /** RSA with SHA-512 signature algorithm URI. */
     public static final String RSA_SHA512 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
 
+    /** Triple DES in CBC mode block-encryption algorithm URI. */
     public static final String TRIPLEDES_CBC = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+    /** AES-128 in CBC mode block-encryption algorithm URI. */
     public static final String AES128_CBC = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+    /** AES-192 in CBC mode block-encryption algorithm URI. */
     public static final String AES192_CBC = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+    /** AES-256 in CBC mode block-encryption algorithm URI. */
     public static final String AES256_CBC = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+    /** AES-128 key wrap algorithm URI. */
     public static final String A128KW = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+    /** AES-192 key wrap algorithm URI. */
     public static final String A192KW = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+    /** AES-256 key wrap algorithm URI. */
     public static final String A256KW = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+    /** RSA v1.5 key transport algorithm URI. */
     public static final String RSA_1_5 = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+    /** RSA-OAEP with MGF1-SHA1 key transport algorithm URI. */
     public static final String RSA_OAEP_MGF1P = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
 
+    /** Enveloped signature transform algorithm URI. */
     public static final String ENVSIG = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
 
     private Constants() {

--- a/core/src/main/java/org/codelibs/saml2/core/util/Preconditions.java
+++ b/core/src/main/java/org/codelibs/saml2/core/util/Preconditions.java
@@ -1,9 +1,13 @@
 package org.codelibs.saml2.core.util;
 
+/**
+ * Utility class providing argument precondition checks.
+ */
 public final class Preconditions {
     /**
      * Throws a IllegalArgumentException if {@code t} is null.
      *
+     * @param <T>     the type of the value being checked
      * @param t       the value to check for null
      * @param message the message to include in the thrown exception
      *

--- a/core/src/main/java/org/codelibs/saml2/core/util/SchemaFactory.java
+++ b/core/src/main/java/org/codelibs/saml2/core/util/SchemaFactory.java
@@ -31,9 +31,18 @@ public abstract class SchemaFactory {
         //not called
     }
 
+    /** URL of the SAML 2.0 metadata schema. */
     public static final URL SAML_SCHEMA_METADATA_2_0 = SchemaFactory.class.getResource("/schemas/saml-schema-metadata-2.0.xsd");
+    /** URL of the SAML 2.0 protocol schema. */
     public static final URL SAML_SCHEMA_PROTOCOL_2_0 = SchemaFactory.class.getResource("/schemas/saml-schema-protocol-2.0.xsd");
 
+    /**
+     * Loads a {@link Schema} from the given URL, resolving referenced schemas and DTDs locally.
+     *
+     * @param schemaUrl the URL of the schema to load
+     * @return the loaded schema
+     * @throws SAXException if the schema cannot be parsed
+     */
     public static Schema loadFromUrl(final URL schemaUrl) throws SAXException {
         final javax.xml.validation.SchemaFactory factory =
                 javax.xml.validation.SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);

--- a/core/src/main/java/org/codelibs/saml2/core/util/Util.java
+++ b/core/src/main/java/org/codelibs/saml2/core/util/Util.java
@@ -118,8 +118,11 @@ public final class Util {
     private static final Logger LOGGER = LoggerFactory.getLogger(Util.class);
 
     private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneOffset.UTC);
+    /** Default prefix used when generating unique IDs. */
     public static final String UNIQUE_ID_PREFIX = "ONELOGIN_";
+    /** XPath expression that locates the Signature of a Response element. */
     public static final String RESPONSE_SIGNATURE_XPATH = "/samlp:Response/ds:Signature";
+    /** XPath expression that locates the Signature of an Assertion element. */
     public static final String ASSERTION_SIGNATURE_XPATH = "/samlp:Response/saml:Assertion/ds:Signature";
     /** Indicates if JAXP 1.5 support has been detected. */
     private static final boolean JAXP_15_SUPPORTED = isJaxp15Supported();
@@ -143,7 +146,7 @@ public final class Util {
      * If for whatever reason this method cannot determine if JAXP 1.5 properties are supported it will indicate the
      * options are supported. This way we don't accidentally disable configuration options.
      *
-     * @return
+     * @return true if JAXP 1.5 properties are supported (or could not be determined)
      */
     public static boolean isJaxp15Supported() {
         boolean supported = true;
@@ -1094,6 +1097,13 @@ public final class Util {
         return signatureData;
     }
 
+    /**
+     * Determines whether a signature using a deprecated algorithm must be rejected.
+     *
+     * @param signAlg             the signature algorithm found on the Signature element
+     * @param rejectDeprecatedAlg whether deprecated algorithms should be rejected
+     * @return true if the deprecated algorithm must be rejected, false otherwise
+     */
     public static boolean mustRejectDeprecatedSignatureAlgo(final String signAlg, final boolean rejectDeprecatedAlg) {
         if (DEPRECATED_ALGOS.contains(signAlg)) {
             final String errorMsg = "Found a deprecated algorithm " + signAlg + " related to the Signature element,";
@@ -1604,6 +1614,8 @@ public final class Util {
     /**
      * Get Status from a Response
      *
+     * @param statusXpath
+     *            The XPath expression used to locate the Status element
      * @param dom
      *            The Response as XML
      *
@@ -1851,6 +1863,8 @@ public final class Util {
     }
 
     /**
+     * Returns the current time as a unix timestamp.
+     *
      * @return the unix timestamp that matches the current time.
      */
     public static Long getCurrentTimeStamp() {

--- a/core/src/main/java/org/codelibs/saml2/core/util/XMLErrorAccumulatorHandler.java
+++ b/core/src/main/java/org/codelibs/saml2/core/util/XMLErrorAccumulatorHandler.java
@@ -10,9 +10,19 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
 
+/**
+ * SAX error handler that accumulates parsing errors, fatal errors and warnings
+ * encountered while parsing an XML document.
+ */
 public class XMLErrorAccumulatorHandler extends DefaultHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(XMLErrorAccumulatorHandler.class);
     private final List<SAXParseException> errors = new ArrayList<>();
+
+    /**
+     * Default constructor.
+     */
+    public XMLErrorAccumulatorHandler() {
+    }
 
     @Override
     public void error(final SAXParseException e) throws SAXException {
@@ -38,10 +48,20 @@ public class XMLErrorAccumulatorHandler extends DefaultHandler {
         }
     }
 
+    /**
+     * Returns the accumulated parsing exceptions.
+     *
+     * @return an unmodifiable list of the accumulated parsing exceptions
+     */
     public List<SAXParseException> getErrorXML() {
         return Collections.unmodifiableList(errors);
     }
 
+    /**
+     * Indicates whether any parsing error, fatal error or warning was accumulated.
+     *
+     * @return {@code true} if at least one issue was accumulated, {@code false} otherwise
+     */
     public boolean hasError() {
         return !errors.isEmpty();
     }

--- a/toolkit/src/main/java/org/codelibs/saml2/Auth.java
+++ b/toolkit/src/main/java/org/codelibs/saml2/Auth.java
@@ -1083,6 +1083,8 @@ public class Auth {
     }
 
     /**
+     * Returns the URL of the IdP Single Sign On Service.
+     *
      * @return The url of the Single Sign On Service
      */
     public String getSSOurl() {
@@ -1090,6 +1092,8 @@ public class Auth {
     }
 
     /**
+     * Returns the URL of the IdP Single Logout Service.
+     *
      * @return The url of the Single Logout Service
      */
     public String getSLOurl() {
@@ -1097,6 +1101,8 @@ public class Auth {
     }
 
     /**
+     * Returns the URL of the IdP Single Logout Service response endpoint.
+     *
      * @return The url of the Single Logout Service Response.
      */
     public String getSLOResponseUrl() {
@@ -1298,6 +1304,8 @@ public class Auth {
     }
 
     /**
+     * Returns whether the user has been authenticated.
+     *
      * @return the authenticated
      */
     public final boolean isAuthenticated() {
@@ -1305,6 +1313,8 @@ public class Auth {
     }
 
     /**
+     * Returns the list of the names of the SAML attributes.
+     *
      * @return the list of the names of the SAML attributes.
      */
     public final List<String> getAttributesName() {
@@ -1312,6 +1322,8 @@ public class Auth {
     }
 
     /**
+     * Returns the set of SAML attributes.
+     *
      * @return the set of SAML attributes.
      */
     public final Map<String, List<String>> getAttributes() {
@@ -1319,6 +1331,8 @@ public class Auth {
     }
 
     /**
+     * Returns the value of the SAML attribute with the given name.
+     *
      * @param name Name of the attribute
      *
      * @return the attribute value
@@ -1328,6 +1342,8 @@ public class Auth {
     }
 
     /**
+     * Returns the NameID of the assertion.
+     *
      * @return the nameID of the assertion
      */
     public final String getNameId() {
@@ -1335,6 +1351,8 @@ public class Auth {
     }
 
     /**
+     * Returns the NameID Format of the assertion.
+     *
      * @return the nameID Format of the assertion
      */
     public final String getNameIdFormat() {
@@ -1342,6 +1360,8 @@ public class Auth {
     }
 
     /**
+     * Returns the NameQualifier of the assertion.
+     *
      * @return the NameQualifier of the assertion
      */
     public final String getNameIdNameQualifier() {
@@ -1349,6 +1369,8 @@ public class Auth {
     }
 
     /**
+     * Returns the SPNameQualifier of the assertion.
+     *
      * @return the SPNameQualifier of the assertion
      */
     public final String getNameIdSPNameQualifier() {
@@ -1356,6 +1378,8 @@ public class Auth {
     }
 
     /**
+     * Returns the SessionIndex of the assertion.
+     *
      * @return the SessionIndex of the assertion
      */
     public final String getSessionIndex() {
@@ -1363,6 +1387,8 @@ public class Auth {
     }
 
     /**
+     * Returns the SessionNotOnOrAfter of the assertion.
+     *
      * @return the SessionNotOnOrAfter of the assertion
      */
     public final Instant getSessionExpiration() {
@@ -1370,6 +1396,8 @@ public class Auth {
     }
 
     /**
+     * Returns the ID of the last message processed.
+     *
      * @return The ID of the last message processed
      */
     public String getLastMessageId() {
@@ -1386,6 +1414,8 @@ public class Auth {
     }
 
     /**
+     * Returns the ID of the last assertion processed.
+     *
      * @return The ID of the last assertion processed
      */
     public String getLastAssertionId() {
@@ -1393,6 +1423,8 @@ public class Auth {
     }
 
     /**
+     * Returns the NotOnOrAfter values of the last assertion processed.
+     *
      * @return The NotOnOrAfter values of the last assertion processed
      */
     public List<Instant> getLastAssertionNotOnOrAfter() {
@@ -1400,6 +1432,8 @@ public class Auth {
     }
 
     /**
+     * Returns the errors from the last operation.
+     *
      * @return an array with the errors, the array is empty when the validation was
      *         successful
      */
@@ -1408,6 +1442,8 @@ public class Auth {
     }
 
     /**
+     * Returns the reason for the last error.
+     *
      * @return the reason for the last error
      */
     public String getLastErrorReason() {
@@ -1415,6 +1451,8 @@ public class Auth {
     }
 
     /**
+     * Returns the exception for the last error.
+     *
      * @return the exception for the last error
      */
     public Exception getLastValidationException() {
@@ -1422,6 +1460,8 @@ public class Auth {
     }
 
     /**
+     * Returns the id of the last request generated (AuthnRequest or LogoutRequest).
+     *
      * @return the id of the last request generated (AuthnRequest or LogoutRequest),
      *         null if none
      */
@@ -1440,6 +1480,8 @@ public class Auth {
     }
 
     /**
+     * Returns the settings used by this Auth instance.
+     *
      * @return the Saml2Settings object. The Settings data.
      */
     public Saml2Settings getSettings() {
@@ -1447,6 +1489,8 @@ public class Auth {
     }
 
     /**
+     * Returns whether debug mode is active.
+     *
      * @return if debug mode is active
      */
     public Boolean isDebugActive() {

--- a/toolkit/src/main/java/org/codelibs/saml2/servlet/ServletUtils.java
+++ b/toolkit/src/main/java/org/codelibs/saml2/servlet/ServletUtils.java
@@ -61,6 +61,8 @@ public class ServletUtils {
     }
 
     /**
+     * Returns the server name of the current request.
+     *
      * @param request
      * 				HttpServletRequest object to be processed
      *


### PR DESCRIPTION
Resolves all Javadoc warnings reported by `mvn clean javadoc:javadoc` (269 in total: 178 "no comment", 80 "no main description", plus a handful of missing/empty `@param`/`@return` tags and default-constructor warnings) across 34 files in the core and toolkit modules.

Changes are Javadoc-only:
- Documented every public SAML URI/algorithm/status constant in `Constants.java`.
- Added leading main descriptions to getters/setters and builder methods that previously had only `@param`/`@return` tags.
- Documented exception classes, their error-code constants and constructors.
- Filled in empty `@param`/`@return` descriptions and the missing `@param <T>` / `@param statusXpath` tags.

No behavior, method signatures or constant values were changed. A few explicit empty no-arg constructors were added solely to satisfy doclint's "use of default constructor" warning; they are behaviorally identical to the implicit defaults.

Verified: `mvn clean javadoc:javadoc` now reports BUILD SUCCESS with zero `warning:` and zero `error:` lines, and `mvn clean compile` succeeds.