### PR TITLE
Harden SAML validation and add opt-in security defenses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Settings loaded from `onelogin.saml.properties` on classpath or programmatically
 
 ### Security Defaults
 
-SHA-256 digest, RSA-SHA256 signatures, 120s clock drift tolerance. `strict` mode must be TRUE in production. Deprecated algorithms (SHA-1) rejected by default.
+SHA-256 digest, RSA-SHA256 signatures, 120s clock drift tolerance. `strict` mode must be TRUE in production. By default, deprecated algorithms are NOT rejected (`rejectDeprecatedAlg` defaults to `false`) and the IdP cert fingerprint algorithm defaults to `sha1`. For production, explicitly set `rejectDeprecatedAlg=true`, `idpCertFingerprintAlgorithm=sha256`, and `wantAssertionsSigned`/`wantMessagesSigned=true`.
 
 ## Test Resources
 

--- a/README.md
+++ b/README.md
@@ -568,7 +568,11 @@ if (!errors.isEmpty()) {
 
     String relayState = request.getParameter("RelayState");
 
-    if (relayState != null && relayState != ServletUtils.getSelfRoutedURLNoQuery(request)) {
+    // SECURITY WARNING: RelayState is attacker-controlled (it comes from an HTTP parameter).
+    // Redirecting to it verbatim is an open-redirect vulnerability. Validate it against an
+    // application-controlled allowlist, or restrict it to a known-safe relative path, before
+    // calling sendRedirect.
+    if (relayState != null && !relayState.equals(ServletUtils.getSelfRoutedURLNoQuery(request))) {
         response.sendRedirect(request.getParameter("RelayState"));
     } else {
         if (attributes.isEmpty()) {

--- a/core/src/main/java/org/codelibs/saml2/core/authn/SamlResponse.java
+++ b/core/src/main/java/org/codelibs/saml2/core/authn/SamlResponse.java
@@ -22,6 +22,7 @@ import org.codelibs.saml2.core.http.HttpRequest;
 import org.codelibs.saml2.core.model.SamlResponseStatus;
 import org.codelibs.saml2.core.model.SubjectConfirmationIssue;
 import org.codelibs.saml2.core.model.hsm.HSM;
+import org.codelibs.saml2.core.replay.ReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.util.Constants;
 import org.codelibs.saml2.core.util.SchemaFactory;
@@ -342,6 +343,21 @@ public class SamlResponse {
                 throw new ValidationException("Signature validation failed. SAML Response rejected", ValidationException.INVALID_SIGNATURE);
             }
 
+            final ReplayCache replayCache = settings.getReplayCache();
+            if (replayCache != null) {
+                final String assertionId = getAssertionId();
+                Instant expiresAt = getSessionNotOnOrAfter();
+                if (expiresAt == null) {
+                    final List<Instant> notOnOrAfters = getAssertionNotOnOrAfter();
+                    expiresAt = notOnOrAfters.isEmpty() ? Instant.now().plusSeconds(settings.getClockDrift() + 300)
+                            : java.util.Collections.min(notOnOrAfters);
+                }
+                if (replayCache.registerAndCheck(assertionId, expiresAt)) {
+                    throw new ValidationException("The Assertion was already processed (replay detected): " + assertionId,
+                            ValidationException.ASSERTION_REPLAYED);
+                }
+            }
+
             LOGGER.debug("SAMLResponse validated --> {}", samlResponseString);
             return true;
         } catch (final Exception e) {
@@ -459,7 +475,7 @@ public class SamlResponse {
                                 SettingsException.PRIVATE_KEY_NOT_FOUND);
                     }
 
-                    Util.decryptElement(encryptedData, key);
+                    Util.decryptElement(encryptedData, key, settings.getAllowedKeyTransportAlgorithms());
                 }
                 nameIdNodes = this.queryAssertion("/saml:Subject/saml:EncryptedID/saml:NameID|/saml:Subject/saml:NameID");
 
@@ -1038,7 +1054,7 @@ public class SamlResponse {
      *
      */
     public boolean validateTimestamps() {
-        final NodeList timestampNodes = samlResponseDocument.getElementsByTagNameNS("*", "Conditions");
+        final NodeList timestampNodes = getSAMLResponseDocument().getElementsByTagNameNS("*", "Conditions");
         if (timestampNodes.getLength() != 0) {
             for (int i = 0; i < timestampNodes.getLength(); i++) {
                 final NamedNodeMap attrName = timestampNodes.item(i).getAttributes();
@@ -1203,14 +1219,14 @@ public class SamlResponse {
         final Element encryptedData = (Element) encryptedDataNodes.item(0);
 
         if (hsm != null) {
-            Util.decryptUsingHsm(encryptedData, hsm);
+            Util.decryptUsingHsm(encryptedData, hsm, settings.getAllowedKeyTransportAlgorithms());
         } else {
-            Util.decryptElement(encryptedData, key);
+            Util.decryptElement(encryptedData, key, settings.getAllowedKeyTransportAlgorithms());
         }
 
         // We need to Remove the saml:EncryptedAssertion Node
         final NodeList AssertionDataNodes = Util.query(dom, "/samlp:Response/saml:EncryptedAssertion/saml:Assertion");
-        if (encryptedDataNodes.getLength() == 0) {
+        if (AssertionDataNodes.getLength() == 0) {
             throw new ValidationException("No /samlp:Response/saml:EncryptedAssertion/saml:Assertion element found",
                     ValidationException.MISSING_ENCRYPTED_ELEMENT);
         }

--- a/core/src/main/java/org/codelibs/saml2/core/exception/SAMLSignatureException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/SAMLSignatureException.java
@@ -17,4 +17,13 @@ public class SAMLSignatureException extends SAMLException {
         super(e);
     }
 
+    /**
+     * Constructs a new {@code SAMLSignatureException} with the given message.
+     *
+     * @param message the detail message
+     */
+    public SAMLSignatureException(final String message) {
+        super(message);
+    }
+
 }

--- a/core/src/main/java/org/codelibs/saml2/core/exception/ValidationException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/ValidationException.java
@@ -108,6 +108,10 @@ public class ValidationException extends SAMLException {
     public static final int MISSING_ENCRYPTED_ELEMENT = 48;
     /** Error code indicating an invalid IssueInstant format. */
     public static final int INVALID_ISSUE_INSTANT_FORMAT = 49;
+    /** Error code indicating the assertion was already processed (replay detected). */
+    public static final int ASSERTION_REPLAYED = 50;
+    /** Error code indicating the logout message was already processed (replay detected). */
+    public static final int MESSAGE_REPLAYED = 51;
 
     /** The error code associated with this validation failure. */
     private final int errorCode;

--- a/core/src/main/java/org/codelibs/saml2/core/logout/LogoutRequest.java
+++ b/core/src/main/java/org/codelibs/saml2/core/logout/LogoutRequest.java
@@ -6,6 +6,7 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +17,7 @@ import org.codelibs.saml2.core.exception.SettingsException;
 import org.codelibs.saml2.core.exception.ValidationException;
 import org.codelibs.saml2.core.exception.XMLParsingException;
 import org.codelibs.saml2.core.http.HttpRequest;
+import org.codelibs.saml2.core.replay.ReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.util.Constants;
 import org.codelibs.saml2.core.util.SchemaFactory;
@@ -389,7 +391,8 @@ public class LogoutRequest {
             }
         }
 
-        final String nameIdStr = Util.generateNameId(nameId, spNameQualifier, nameIdFormat, nameQualifier, cert);
+        final String nameIdStr =
+                Util.generateNameId(nameId, spNameQualifier, nameIdFormat, nameQualifier, cert, settings.getNameIdEncryptionAlgorithm());
         valueMap.put("nameIdStr", nameIdStr);
 
         String sessionIndexStr = "";
@@ -470,7 +473,7 @@ public class LogoutRequest {
                     }
                 }
 
-                getNameId(logoutRequestDocument, settings.getSPkey(), settings.isTrimNameIds());
+                getNameId(logoutRequestDocument, settings.getSPkey(), settings.isTrimNameIds(), settings.getAllowedKeyTransportAlgorithms());
 
                 // Check the issuer
                 final String issuer = getIssuer(logoutRequestDocument, settings.isTrimNameIds());
@@ -527,6 +530,16 @@ public class LogoutRequest {
                 if (!Util.validateBinarySignature(signedQuery.toString(), Util.base64decoder(signature), certList, signAlg)) {
                     throw new ValidationException("Signature validation failed. Logout Request rejected",
                             ValidationException.INVALID_SIGNATURE);
+                }
+            }
+
+            final ReplayCache replayCache = settings.getReplayCache();
+            if (replayCache != null) {
+                final String messageId = getId();
+                final Instant expiresAt = Instant.now().plusSeconds(settings.getClockDrift() + 300);
+                if (replayCache.registerAndCheck(messageId, expiresAt)) {
+                    throw new ValidationException("The LogoutRequest was already processed (replay detected): " + messageId,
+                            ValidationException.MESSAGE_REPLAYED);
                 }
             }
 
@@ -642,6 +655,28 @@ public class LogoutRequest {
      */
     public static Map<String, String> getNameIdData(final Document samlLogoutRequestDocument, final PrivateKey key,
             final boolean trimValue) {
+        return getNameIdData(samlLogoutRequestDocument, key, trimValue, null);
+    }
+
+    /**
+     * Gets the NameID Data from the the Logout Request Document, optionally restricting the accepted
+     * key transport (key wrapping) algorithm of an encrypted NameID to an allow-list.
+     *
+     * @param samlLogoutRequestDocument
+     *              A DOMDocument object loaded from the SAML Logout Request.
+     * @param key
+     *              The SP key to decrypt the NameID if encrypted
+     * @param trimValue
+     *              whether the extracted Name ID value should be trimmed
+     * @param allowedKeyTransportAlgorithms
+     *              The set of allowed key transport algorithm URIs. If {@code null} or empty, every
+     *              algorithm is accepted, preserving the historical permissive behavior.
+     *
+     * @return the Name ID Data (Value, Format, NameQualifier, SPNameQualifier)
+     *
+     */
+    public static Map<String, String> getNameIdData(final Document samlLogoutRequestDocument, final PrivateKey key,
+            final boolean trimValue, final Collection<String> allowedKeyTransportAlgorithms) {
         try {
             final NodeList encryptedIDNodes = Util.query(samlLogoutRequestDocument, "/samlp:LogoutRequest/saml:EncryptedID");
             NodeList nameIdNodes;
@@ -653,7 +688,7 @@ public class LogoutRequest {
                 }
 
                 final Element encryptedData = (Element) encryptedIDNodes.item(0);
-                Util.decryptElement(encryptedData, key);
+                Util.decryptElement(encryptedData, key, allowedKeyTransportAlgorithms);
                 nameIdNodes = Util.query(samlLogoutRequestDocument, "/samlp:LogoutRequest/saml:NameID");
 
                 if (nameIdNodes == null || nameIdNodes.getLength() != 1) {
@@ -760,7 +795,32 @@ public class LogoutRequest {
      *
      */
     public static String getNameId(final Document samlLogoutRequestDocument, final PrivateKey key, final boolean trimValue) {
-        final Map<String, String> nameIdData = getNameIdData(samlLogoutRequestDocument, key, trimValue);
+        return getNameId(samlLogoutRequestDocument, key, trimValue, null);
+    }
+
+    /**
+     * Gets the NameID value provided from the SAML Logout Request Document, optionally restricting the
+     * accepted key transport (key wrapping) algorithm of an encrypted NameID to an allow-list.
+     *
+     * @param samlLogoutRequestDocument
+     *              A DOMDocument object loaded from the SAML Logout Request.
+     *
+     * @param key
+     *              The SP key to decrypt the NameID if encrypted
+     *
+     * @param trimValue
+     *              whether the extracted Name ID value should be trimmed
+     *
+     * @param allowedKeyTransportAlgorithms
+     *              The set of allowed key transport algorithm URIs. If {@code null} or empty, every
+     *              algorithm is accepted, preserving the historical permissive behavior.
+     *
+     * @return the Name ID value
+     *
+     */
+    public static String getNameId(final Document samlLogoutRequestDocument, final PrivateKey key, final boolean trimValue,
+            final Collection<String> allowedKeyTransportAlgorithms) {
+        final Map<String, String> nameIdData = getNameIdData(samlLogoutRequestDocument, key, trimValue, allowedKeyTransportAlgorithms);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("LogoutRequest has NameID --> {}", nameIdData.get("Value"));
         }

--- a/core/src/main/java/org/codelibs/saml2/core/logout/LogoutResponse.java
+++ b/core/src/main/java/org/codelibs/saml2/core/logout/LogoutResponse.java
@@ -2,6 +2,7 @@ package org.codelibs.saml2.core.logout;
 
 import java.net.URL;
 import java.security.cert.X509Certificate;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -14,6 +15,7 @@ import org.codelibs.saml2.core.exception.SettingsException;
 import org.codelibs.saml2.core.exception.ValidationException;
 import org.codelibs.saml2.core.http.HttpRequest;
 import org.codelibs.saml2.core.model.SamlResponseStatus;
+import org.codelibs.saml2.core.replay.ReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.util.Constants;
 import org.codelibs.saml2.core.util.SchemaFactory;
@@ -289,6 +291,16 @@ public class LogoutResponse {
                 if (!Util.validateBinarySignature(signedQuery.toString(), Util.base64decoder(signature), certList, signAlg)) {
                     throw new ValidationException("Signature validation failed. Logout Response rejected",
                             ValidationException.INVALID_SIGNATURE);
+                }
+            }
+
+            final ReplayCache replayCache = settings.getReplayCache();
+            if (replayCache != null) {
+                final String messageId = getId();
+                final Instant expiresAt = Instant.now().plusSeconds(settings.getClockDrift() + 300);
+                if (replayCache.registerAndCheck(messageId, expiresAt)) {
+                    throw new ValidationException("The LogoutResponse was already processed (replay detected): " + messageId,
+                            ValidationException.MESSAGE_REPLAYED);
                 }
             }
 

--- a/core/src/main/java/org/codelibs/saml2/core/replay/InMemoryReplayCache.java
+++ b/core/src/main/java/org/codelibs/saml2/core/replay/InMemoryReplayCache.java
@@ -1,0 +1,64 @@
+package org.codelibs.saml2.core.replay;
+
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Default in-memory, thread-safe {@link ReplayCache} implementation backed by a
+ * {@link ConcurrentHashMap}. Expired entries are evicted opportunistically (no
+ * background threads are started by this class).
+ */
+public class InMemoryReplayCache implements ReplayCache {
+
+    /** Number of registrations between opportunistic sweeps of expired entries. */
+    private static final long SWEEP_INTERVAL = 1000L;
+
+    /** Map of id to the instant after which the entry may be evicted. */
+    private final ConcurrentHashMap<String, Instant> entries = new ConcurrentHashMap<>();
+
+    /** Counts registrations to decide when to opportunistically sweep expired entries. */
+    private final AtomicLong registrationCount = new AtomicLong();
+
+    /**
+     * Constructs a new, empty {@code InMemoryReplayCache}.
+     */
+    public InMemoryReplayCache() {
+        // No-op: entries map starts empty.
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean registerAndCheck(final String id, final Instant expiresAt) {
+        final Instant now = Instant.now();
+        final AtomicBoolean replay = new AtomicBoolean(false);
+
+        entries.compute(id, (key, previousExpiresAt) -> {
+            if (previousExpiresAt != null && previousExpiresAt.isAfter(now)) {
+                // Still-valid previous entry: this is a replay, keep the existing expiry.
+                replay.set(true);
+                return previousExpiresAt;
+            }
+            // No previous entry, or the previous entry already expired: treat as a first use.
+            replay.set(false);
+            return expiresAt;
+        });
+
+        if (registrationCount.incrementAndGet() % SWEEP_INTERVAL == 0) {
+            sweep(now);
+        }
+
+        return replay.get();
+    }
+
+    /**
+     * Opportunistically removes entries whose expiry is not after the given instant.
+     *
+     * @param now the instant to compare entry expiries against
+     */
+    private void sweep(final Instant now) {
+        entries.entrySet().removeIf(entry -> !entry.getValue().isAfter(now));
+    }
+
+}

--- a/core/src/main/java/org/codelibs/saml2/core/replay/ReplayCache.java
+++ b/core/src/main/java/org/codelibs/saml2/core/replay/ReplayCache.java
@@ -1,0 +1,20 @@
+package org.codelibs.saml2.core.replay;
+
+import java.time.Instant;
+
+/**
+ * Thread-safe store for detecting replayed SAML message/assertion IDs.
+ * Implementations MUST be thread-safe.
+ */
+public interface ReplayCache {
+
+    /**
+     * Atomically records the id if unseen and reports whether it was already present.
+     *
+     * @param id the assertion or message ID
+     * @param expiresAt instant after which the entry may be evicted (never null)
+     * @return true if id was already registered (=&gt; replay); false if newly registered (first use)
+     */
+    boolean registerAndCheck(String id, Instant expiresAt);
+
+}

--- a/core/src/main/java/org/codelibs/saml2/core/settings/IdPMetadataParser.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/IdPMetadataParser.java
@@ -3,10 +3,12 @@ package org.codelibs.saml2.core.settings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.security.cert.X509Certificate;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.codelibs.saml2.core.exception.SAMLSevereException;
+import org.codelibs.saml2.core.exception.SAMLSignatureException;
 import org.codelibs.saml2.core.exception.XMLParsingException;
 import org.codelibs.saml2.core.util.Constants;
 import org.codelibs.saml2.core.util.Util;
@@ -24,6 +26,17 @@ import org.xml.sax.InputSource;
  *
  * This class does not validate in any way the URL that is introduced,
  * make sure to validate it properly before use it in a get_metadata method.
+ *
+ * <p><b>Security note on {@code trustedSigningCert} overloads:</b> the overloads of
+ * {@code parseXML}/{@code parseFileXML}/{@code parseRemoteXML} that accept a trailing
+ * {@link X509Certificate} verify that the fetched metadata document is signed by that
+ * certificate before parsing it. That certificate MUST be provisioned out-of-band
+ * (e.g. from pinned configuration or a local keystore) and MUST NOT be extracted from
+ * the very same metadata document being validated. Extracting the trust anchor from the
+ * document under validation only protects against transport-level corruption; it does
+ * nothing to detect a MITM attacker or a compromised source serving a self-consistent
+ * forged document, since the attacker would simply embed their own certificate alongside
+ * their own signature.
  */
 public class IdPMetadataParser {
 
@@ -154,6 +167,42 @@ public class IdPMetadataParser {
     }
 
     /**
+     * Get IdP Metadata Info from XML Document, verifying beforehand that the document is signed
+     * by the given trusted certificate.
+     *
+     * <p><b>Security note:</b> {@code trustedSigningCert} MUST be provisioned out-of-band (e.g.
+     * pinned configuration or a local keystore entry), NOT extracted from the same metadata
+     * document being validated here. Using a certificate embedded in the document under
+     * validation only detects transport corruption, not a MITM attacker or a compromised source
+     * serving a self-consistent forged document (which would simply embed its own certificate
+     * alongside its own signature).
+     *
+     * @param xmlDocument
+     *            XML document hat contains IdP metadata
+     * @param entityId
+     *            Entity Id of the desired IdP, if no entity Id is provided and the XML metadata contains more than one IDPSSODescriptor, the first is returned
+     * @param desiredNameIdFormat
+     *            If available on IdP metadata, use that nameIdFormat
+     * @param desiredSSOBinding
+     *            Parse specific binding SSO endpoint.
+     * @param desiredSLOBinding
+     *            Parse specific binding SLO endpoint.
+     * @param trustedSigningCert
+     *            the out-of-band trusted certificate the metadata document must be signed with; if {@code null} no signature check is performed
+     *
+     * @return Mapped values with metadata info in Saml2Settings format
+     *
+     * @throws SAMLSignatureException if {@code trustedSigningCert} is not {@code null} and the metadata document signature does not validate against it
+     */
+    public static Map<String, Object> parseXML(final Document xmlDocument, final String entityId, final String desiredNameIdFormat,
+            final String desiredSSOBinding, final String desiredSLOBinding, final X509Certificate trustedSigningCert) {
+        if (trustedSigningCert != null && !Util.validateMetadataSign(xmlDocument, trustedSigningCert, null, null)) {
+            throw new SAMLSignatureException("Metadata signature validation failed (entityId=" + entityId + ")");
+        }
+        return parseXML(xmlDocument, entityId, desiredNameIdFormat, desiredSSOBinding, desiredSLOBinding);
+    }
+
+    /**
      * Get IdP Metadata Info from XML Document
      *
      * @param xmlDocument
@@ -215,6 +264,75 @@ public class IdPMetadataParser {
     }
 
     /**
+     * Get IdP Metadata Info from XML file, verifying beforehand that the document is signed by
+     * the given trusted certificate.
+     *
+     * <p><b>Security note:</b> {@code trustedSigningCert} MUST be provisioned out-of-band (e.g.
+     * pinned configuration or a local keystore entry), NOT extracted from the same metadata
+     * document being validated here. See {@link #parseXML(Document, String, String, String, String, X509Certificate)}
+     * for details.
+     *
+     * @param xmlFileName
+     *            Filename of the XML filename that contains IdP metadata
+     * @param entityId
+     *            Entity Id of the desired IdP, if no entity Id is provided and the XML metadata contains more than one IDPSSODescriptor, the first is returned
+     * @param desiredNameIdFormat
+     *            If available on IdP metadata, use that nameIdFormat
+     * @param desiredSSOBinding
+     *            Parse specific binding SSO endpoint.
+     * @param desiredSLOBinding
+     *            Parse specific binding SLO endpoint.
+     * @param trustedSigningCert
+     *            the out-of-band trusted certificate the metadata document must be signed with; if {@code null} no signature check is performed
+     *
+     * @return Mapped values with metadata info in Saml2Settings format
+     *
+     * @throws SAMLSignatureException if {@code trustedSigningCert} is not {@code null} and the metadata document signature does not validate against it
+     */
+    public static Map<String, Object> parseFileXML(final String xmlFileName, final String entityId, final String desiredNameIdFormat,
+            final String desiredSSOBinding, final String desiredSLOBinding, final X509Certificate trustedSigningCert) {
+        final ClassLoader classLoader = IdPMetadataParser.class.getClassLoader();
+        try (InputStream inputStream = classLoader.getResourceAsStream(xmlFileName)) {
+            if (inputStream != null) {
+                final Document xmlDocument = Util.parseXML(new InputSource(inputStream));
+                return parseXML(xmlDocument, entityId, desiredNameIdFormat, desiredSSOBinding, desiredSLOBinding, trustedSigningCert);
+            }
+        } catch (final SAMLSignatureException e) {
+            throw e;
+        } catch (final Exception e) {
+            final String errorMsg = "XML file'" + xmlFileName + "' cannot be loaded." + e.getMessage();
+            throw new SAMLSevereException(errorMsg, SAMLSevereException.SETTINGS_FILE_NOT_FOUND, e);
+        }
+        throw new SAMLSevereException("XML file '" + xmlFileName + "' not found in the classpath",
+                SAMLSevereException.SETTINGS_FILE_NOT_FOUND);
+    }
+
+    /**
+     * Get IdP Metadata Info from XML file, verifying beforehand that the document is signed by
+     * the given trusted certificate. Shorthand for
+     * {@link #parseFileXML(String, String, String, String, String, X509Certificate)} with
+     * {@code entityId=null}, {@code desiredNameIdFormat=null} and both bindings set to
+     * {@link Constants#BINDING_HTTP_REDIRECT}.
+     *
+     * <p><b>Security note:</b> {@code trustedSigningCert} MUST be provisioned out-of-band, NOT
+     * extracted from the same metadata document being validated here. See
+     * {@link #parseXML(Document, String, String, String, String, X509Certificate)} for details.
+     *
+     * @param xmlFileName
+     *            Filename of the XML filename that contains IdP metadata
+     * @param trustedSigningCert
+     *            the out-of-band trusted certificate the metadata document must be signed with; if {@code null} no signature check is performed
+     *
+     * @return Mapped values with metadata info in Saml2Settings format
+     *
+     * @throws SAMLSignatureException if {@code trustedSigningCert} is not {@code null} and the metadata document signature does not validate against it
+     */
+    public static Map<String, Object> parseFileXML(final String xmlFileName, final X509Certificate trustedSigningCert) {
+        return parseFileXML(xmlFileName, null, null, Constants.BINDING_HTTP_REDIRECT, Constants.BINDING_HTTP_REDIRECT,
+                trustedSigningCert);
+    }
+
+    /**
      * Get IdP Metadata Info from XML file
      *
      * @param xmlFileName
@@ -239,7 +357,7 @@ public class IdPMetadataParser {
      *
      */
     public static Map<String, Object> parseFileXML(final String xmlFileName) {
-        return parseFileXML(xmlFileName, null);
+        return parseFileXML(xmlFileName, (String) null);
     }
 
     /**
@@ -270,6 +388,66 @@ public class IdPMetadataParser {
     }
 
     /**
+     * Get IdP Metadata Info from XML file, verifying beforehand that the document is signed by
+     * the given trusted certificate.
+     *
+     * <p><b>Security note:</b> {@code trustedSigningCert} MUST be provisioned out-of-band (e.g.
+     * pinned configuration or a local keystore entry), NOT extracted from the same metadata
+     * document being validated here. See {@link #parseXML(Document, String, String, String, String, X509Certificate)}
+     * for details.
+     *
+     * @param xmlURL
+     *            URL to the XML document that contains IdP metadata
+     * @param entityId
+     *            Entity Id of the desired IdP, if no entity Id is provided and the XML metadata contains more than one IDPSSODescriptor, the first is returned
+     * @param desiredNameIdFormat
+     *            If available on IdP metadata, use that nameIdFormat
+     * @param desiredSSOBinding
+     *            Parse specific binding SSO endpoint.
+     * @param desiredSLOBinding
+     *            Parse specific binding SLO endpoint.
+     * @param trustedSigningCert
+     *            the out-of-band trusted certificate the metadata document must be signed with; if {@code null} no signature check is performed
+     *
+     * @return Mapped values with metadata info in Saml2Settings format
+     *
+     * @throws SAMLSignatureException if {@code trustedSigningCert} is not {@code null} and the metadata document signature does not validate against it
+     */
+    public static Map<String, Object> parseRemoteXML(final URL xmlURL, final String entityId, final String desiredNameIdFormat,
+            final String desiredSSOBinding, final String desiredSLOBinding, final X509Certificate trustedSigningCert) {
+        try (InputStream is = xmlURL.openStream()) {
+            final Document xmlDocument = Util.parseXML(new InputSource(is));
+            return parseXML(xmlDocument, entityId, desiredNameIdFormat, desiredSSOBinding, desiredSLOBinding, trustedSigningCert);
+        } catch (IOException e) {
+            throw new XMLParsingException("Failed to parse a remote XML: " + xmlURL, e);
+        }
+    }
+
+    /**
+     * Get IdP Metadata Info from XML file, verifying beforehand that the document is signed by
+     * the given trusted certificate. Shorthand for
+     * {@link #parseRemoteXML(URL, String, String, String, String, X509Certificate)} with
+     * {@code entityId=null}, {@code desiredNameIdFormat=null} and both bindings set to
+     * {@link Constants#BINDING_HTTP_REDIRECT}.
+     *
+     * <p><b>Security note:</b> {@code trustedSigningCert} MUST be provisioned out-of-band, NOT
+     * extracted from the same metadata document being validated here. See
+     * {@link #parseXML(Document, String, String, String, String, X509Certificate)} for details.
+     *
+     * @param xmlURL
+     *            URL to the XML document that contains IdP metadata
+     * @param trustedSigningCert
+     *            the out-of-band trusted certificate the metadata document must be signed with; if {@code null} no signature check is performed
+     *
+     * @return Mapped values with metadata info in Saml2Settings format
+     *
+     * @throws SAMLSignatureException if {@code trustedSigningCert} is not {@code null} and the metadata document signature does not validate against it
+     */
+    public static Map<String, Object> parseRemoteXML(final URL xmlURL, final X509Certificate trustedSigningCert) {
+        return parseRemoteXML(xmlURL, null, null, Constants.BINDING_HTTP_REDIRECT, Constants.BINDING_HTTP_REDIRECT, trustedSigningCert);
+    }
+
+    /**
      * Get IdP Metadata Info from XML file
      *
      * @param xmlURL
@@ -294,7 +472,7 @@ public class IdPMetadataParser {
      *
      */
     public static Map<String, Object> parseRemoteXML(final URL xmlURL) {
-        return parseRemoteXML(xmlURL, null);
+        return parseRemoteXML(xmlURL, (String) null);
     }
 
     /**

--- a/core/src/main/java/org/codelibs/saml2/core/settings/Saml2Settings.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/Saml2Settings.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.codelibs.saml2.core.model.Contact;
 import org.codelibs.saml2.core.model.Organization;
 import org.codelibs.saml2.core.model.hsm.HSM;
+import org.codelibs.saml2.core.replay.ReplayCache;
 import org.codelibs.saml2.core.util.Constants;
 import org.codelibs.saml2.core.util.SchemaFactory;
 import org.codelibs.saml2.core.util.Util;
@@ -54,6 +55,7 @@ public class Saml2Settings {
     private X509Certificate spX509certNew = null;
     private PrivateKey spPrivateKey = null;
     private HSM hsm = null;
+    private ReplayCache replayCache = null;
 
     // IdP
     private String idpEntityId = "";
@@ -83,6 +85,8 @@ public class Saml2Settings {
     private boolean wantXMLValidation = true;
     private String signatureAlgorithm = Constants.RSA_SHA256;
     private String digestAlgorithm = Constants.SHA256;
+    private String nameIdEncryptionAlgorithm = Constants.RSA_1_5;
+    private Set<String> allowedKeyTransportAlgorithms = null;
     private boolean rejectUnsolicitedResponsesWithInResponseTo = false;
     private boolean allowRepeatAttributeName = false;
     private boolean rejectDeprecatedAlg = false;
@@ -321,6 +325,15 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the key transport (key wrapping) algorithm used to encrypt the NameID.
+     *
+     * @return the nameIdEncryptionAlgorithm setting value
+     */
+    public String getNameIdEncryptionAlgorithm() {
+        return nameIdEncryptionAlgorithm;
+    }
+
+    /**
      * Returns whether authentication requests should be signed.
      *
      * @return the authnRequestsSigned setting value
@@ -447,6 +460,17 @@ public class Saml2Settings {
     }
 
     /**
+     * Returns the allow-list of key transport (key wrapping) algorithm URIs accepted when
+     * decrypting an inbound {@code xenc:EncryptedKey}.
+     *
+     * @return the allowedKeyTransportAlgorithms setting value, or {@code null} if every
+     *         algorithm is accepted (permissive default)
+     */
+    public Set<String> getAllowedKeyTransportAlgorithms() {
+        return allowedKeyTransportAlgorithms;
+    }
+
+    /**
      * Returns the Service Provider contact information.
      *
      * @return SP Contact info
@@ -480,6 +504,17 @@ public class Saml2Settings {
      */
     public HSM getHsm() {
         return this.hsm;
+    }
+
+    /**
+     * Returns the configured replay cache used to detect replayed SAML assertions
+     * and logout messages.
+     *
+     * @return the ReplayCache setting value, or {@code null} if replay checking is
+     *         not configured (the default).
+     */
+    public ReplayCache getReplayCache() {
+        return this.replayCache;
     }
 
     /**
@@ -537,6 +572,16 @@ public class Saml2Settings {
      */
     public void setHsm(final HSM hsm) {
         this.hsm = hsm;
+    }
+
+    /**
+     * Sets the replay cache used to detect replayed SAML assertions and logout
+     * messages. When {@code null} (the default), no replay checking is performed.
+     *
+     * @param replayCache The ReplayCache object to be set.
+     */
+    public void setReplayCache(final ReplayCache replayCache) {
+        this.replayCache = replayCache;
     }
 
     /**
@@ -922,6 +967,29 @@ public class Saml2Settings {
     }
 
     /**
+     * Set the nameIdEncryptionAlgorithm setting value
+     *
+     * @param nameIdEncryptionAlgorithm
+     *            the nameIdEncryptionAlgorithm value to be set. The key transport (key wrapping)
+     *            algorithm used when encrypting the NameID.
+     */
+    public void setNameIdEncryptionAlgorithm(final String nameIdEncryptionAlgorithm) {
+        this.nameIdEncryptionAlgorithm = nameIdEncryptionAlgorithm;
+    }
+
+    /**
+     * Set the allowedKeyTransportAlgorithms setting value
+     *
+     * @param allowedKeyTransportAlgorithms
+     *            the allow-list of key transport (key wrapping) algorithm URIs accepted when
+     *            decrypting an inbound {@code xenc:EncryptedKey}. {@code null} accepts every
+     *            algorithm (permissive default).
+     */
+    public void setAllowedKeyTransportAlgorithms(final Set<String> allowedKeyTransportAlgorithms) {
+        this.allowedKeyTransportAlgorithms = allowedKeyTransportAlgorithms;
+    }
+
+    /**
      * Controls if unsolicited Responses are rejected if they contain an InResponseTo value.
      *
      * If false using a validate method {@link org.codelibs.saml2.core.authn.SamlResponse#isValid(String)} with a null argument will
@@ -1072,6 +1140,31 @@ public class Saml2Settings {
         }
 
         return errors;
+    }
+
+    /**
+     * Returns a list of non-fatal security warnings about the current configuration. Unlike
+     * {@link #checkSettings()}, these are not configuration errors, but weak or insecure
+     * settings that should be reviewed before running in production.
+     *
+     * @return the list of security warning codes found on the settings data
+     */
+    public List<String> getSecurityWarnings() {
+        final List<String> warnings = new ArrayList<>();
+        if (!strict) {
+            warnings.add("strict_mode_disabled");
+        }
+        if (idpCertFingerprint != null && !"sha256".equalsIgnoreCase(idpCertFingerprintAlgorithm)
+                && !"sha384".equalsIgnoreCase(idpCertFingerprintAlgorithm) && !"sha512".equalsIgnoreCase(idpCertFingerprintAlgorithm)) {
+            warnings.add("weak_fingerprint_algorithm");
+        }
+        if (!rejectDeprecatedAlg) {
+            warnings.add("deprecated_signature_algorithms_not_rejected");
+        }
+        if (!wantAssertionsSigned && !wantMessagesSigned) {
+            warnings.add("assertions_and_messages_not_required_signed");
+        }
+        return warnings;
     }
 
     /**
@@ -1275,12 +1368,52 @@ public class Saml2Settings {
     /**
      * Validates an XML SP Metadata.
      *
+     * <p>This overload never performs metadata signature validation; it is preserved
+     * unchanged for backward compatibility. Use {@link #validateMetadata(String, X509Certificate)}
+     * or {@link #validateMetadata(String, X509Certificate, String, String, boolean)} to additionally
+     * validate the metadata signature.
+     *
      * @param metadataString Metadata's XML that will be validate
      *
      * @return Array The list of found errors
      *
      */
-    public static List<String> validateMetadata(String metadataString) {
+    public static List<String> validateMetadata(final String metadataString) {
+        return validateMetadata(metadataString, null, null, null, false);
+    }
+
+    /**
+     * Validates an XML SP Metadata, additionally checking that it is signed by the given certificate.
+     *
+     * @param metadataString Metadata's XML that will be validate
+     * @param cert the certificate whose public key is used to validate the metadata's signature
+     *
+     * @return Array The list of found errors
+     *
+     */
+    public static List<String> validateMetadata(final String metadataString, final X509Certificate cert) {
+        return validateMetadata(metadataString, cert, null, null, false);
+    }
+
+    /**
+     * Validates an XML SP Metadata, additionally checking that it is signed either by the given
+     * certificate or by a certificate matching the given fingerprint.
+     *
+     * <p>Signature validation is opt-in: it is only performed when {@code cert} is non-null or
+     * {@code fingerprint} is non-null/non-empty. When neither is provided this method behaves
+     * exactly like {@link #validateMetadata(String)}.
+     *
+     * @param metadataString Metadata's XML that will be validate
+     * @param cert the certificate whose public key is used to validate the metadata's signature, or {@code null}
+     * @param fingerprint the fingerprint of the certificate used to validate the metadata's signature, or {@code null}
+     * @param alg the fingerprint algorithm
+     * @param rejectDeprecatedAlg whether to reject signatures using deprecated algorithms
+     *
+     * @return Array The list of found errors
+     *
+     */
+    public static List<String> validateMetadata(String metadataString, final X509Certificate cert, final String fingerprint,
+            final String alg, final boolean rejectDeprecatedAlg) {
 
         metadataString = metadataString.replace("<?xml version=\"1.0\"?>", "");
 
@@ -1316,14 +1449,11 @@ public class Saml2Settings {
             }
         }
 
-        // Note: Metadata signature validation is not currently implemented.
-        // Future enhancement: Add signature validation for SP metadata to ensure integrity.
-        // Implementation considerations:
-        // - Need to determine which certificate to use for validation (SP cert or dedicated metadata cert)
-        // - Should validation be mandatory or optional based on configuration?
-        // - Use Util.validateMetadataSign() or similar validation method
-        // - Add appropriate error messages to the errors list if validation fails
-        // Security recommendation: Metadata signatures should be validated when received from external sources.
+        if (cert != null || (fingerprint != null && !fingerprint.isEmpty())) {
+            if (!Util.validateMetadataSign(metadataDocument, cert, fingerprint, alg, rejectDeprecatedAlg)) {
+                errors.add("metadata_signature_invalid");
+            }
+        }
 
         return errors;
     }

--- a/core/src/main/java/org/codelibs/saml2/core/settings/SettingsBuilder.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/SettingsBuilder.java
@@ -15,12 +15,14 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -169,6 +171,10 @@ public class SettingsBuilder {
     public final static String SECURITY_SIGNATURE_ALGORITHM = "onelogin.saml2.security.signature_algorithm";
     /** Property key for the digest algorithm used when signing ({@code onelogin.saml2.security.digest_algorithm}). */
     public final static String SECURITY_DIGEST_ALGORITHM = "onelogin.saml2.security.digest_algorithm";
+    /** Property key for the key transport algorithm used to encrypt the NameID ({@code onelogin.saml2.security.nameid_encryption_algorithm}). */
+    public final static String SECURITY_NAMEID_ENCRYPTION_ALGORITHM = "onelogin.saml2.security.nameid_encryption_algorithm";
+    /** Property key for the comma-separated allow-list of key transport algorithms accepted on decrypt ({@code onelogin.saml2.security.allowed_key_transport_algorithms}). */
+    public final static String SECURITY_ALLOWED_KEY_TRANSPORT_ALGORITHMS = "onelogin.saml2.security.allowed_key_transport_algorithms";
     /** Property key controlling whether unsolicited responses with an InResponseTo attribute are rejected ({@code onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto}). */
     public final static String SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO =
             "onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto";
@@ -379,6 +385,12 @@ public class SettingsBuilder {
             saml2Setting.setUniqueIDPrefix(Util.UNIQUE_ID_PREFIX);
         }
 
+        if (LOGGER.isWarnEnabled()) {
+            for (final String warning : saml2Setting.getSecurityWarnings()) {
+                LOGGER.warn("SAML security warning: {}", warning);
+            }
+        }
+
         return saml2Setting;
     }
 
@@ -514,6 +526,22 @@ public class SettingsBuilder {
         final String digestAlgorithm = loadStringProperty(SECURITY_DIGEST_ALGORITHM);
         if (digestAlgorithm != null && !digestAlgorithm.isEmpty()) {
             saml2Setting.setDigestAlgorithm(digestAlgorithm);
+        }
+
+        final String nameIdEncryptionAlgorithm = loadStringProperty(SECURITY_NAMEID_ENCRYPTION_ALGORITHM);
+        if (nameIdEncryptionAlgorithm != null && !nameIdEncryptionAlgorithm.isEmpty()) {
+            saml2Setting.setNameIdEncryptionAlgorithm(nameIdEncryptionAlgorithm);
+        }
+
+        final List<String> allowedKeyTransportAlgorithms = loadListProperty(SECURITY_ALLOWED_KEY_TRANSPORT_ALGORITHMS);
+        if (allowedKeyTransportAlgorithms != null) {
+            final Set<String> allowedKeyTransportAlgorithmsSet = new HashSet<>();
+            for (final String allowedKeyTransportAlgorithm : allowedKeyTransportAlgorithms) {
+                if (allowedKeyTransportAlgorithm != null && !allowedKeyTransportAlgorithm.trim().isEmpty()) {
+                    allowedKeyTransportAlgorithmsSet.add(allowedKeyTransportAlgorithm.trim());
+                }
+            }
+            saml2Setting.setAllowedKeyTransportAlgorithms(allowedKeyTransportAlgorithmsSet);
         }
 
         final Boolean rejectUnsolicitedResponsesWithInResponseTo =

--- a/core/src/main/java/org/codelibs/saml2/core/util/Util.java
+++ b/core/src/main/java/org/codelibs/saml2/core/util/Util.java
@@ -37,6 +37,7 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAmount;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1242,11 +1243,36 @@ public final class Util {
      * 				 The private key to decrypt.
      */
     public static void decryptElement(final Element encryptedDataElement, final PrivateKey inputKey) {
+        decryptElement(encryptedDataElement, inputKey, null);
+    }
+
+    /**
+     * Decrypt an encrypted element, optionally restricting the accepted key transport
+     * (key wrapping) algorithm of the inbound {@code xenc:EncryptedKey} to an allow-list.
+     *
+     * @param encryptedDataElement
+     * 				 The encrypted element.
+     * @param inputKey
+     * 				 The private key to decrypt.
+     * @param allowedKeyTransportAlgorithms
+     * 				 The set of allowed key transport algorithm URIs. If {@code null} or empty, every
+     * 				 algorithm is accepted, preserving the historical permissive behavior.
+     */
+    public static void decryptElement(final Element encryptedDataElement, final PrivateKey inputKey,
+            final Collection<String> allowedKeyTransportAlgorithms) {
         try {
             final XMLCipher xmlCipher = XMLCipher.getInstance();
             xmlCipher.init(XMLCipher.DECRYPT_MODE, null);
 
             validateEncryptedData(encryptedDataElement);
+
+            final String keyTransportAlgorithm = findKeyTransportAlgorithm(encryptedDataElement);
+            if (keyTransportAlgorithm != null && !isKeyTransportAlgorithmAllowed(keyTransportAlgorithm, allowedKeyTransportAlgorithms)) {
+                // Do not throw a distinct exception: an algorithm rejection must be indistinguishable
+                // from any other decryption failure (e.g. a wrong key) to avoid a new side channel.
+                LOGGER.warn("Failed to decrypt an element.");
+                return;
+            }
 
             xmlCipher.setKEK(inputKey);
             xmlCipher.doFinal(encryptedDataElement.getOwnerDocument(), encryptedDataElement, false);
@@ -1263,6 +1289,22 @@ public final class Util {
      *
      */
     public static void decryptUsingHsm(final Element encryptedDataElement, final HSM hsm) {
+        decryptUsingHsm(encryptedDataElement, hsm, null);
+    }
+
+    /**
+     * Decrypts the encrypted element using an HSM, optionally restricting the accepted key
+     * transport (key wrapping) algorithm of the inbound {@code xenc:EncryptedKey} to an allow-list.
+     *
+     * @param encryptedDataElement The encrypted element.
+     * @param hsm The HSM object.
+     * @param allowedKeyTransportAlgorithms
+     * 				 The set of allowed key transport algorithm URIs. If {@code null} or empty, every
+     * 				 algorithm is accepted, preserving the historical permissive behavior.
+     *
+     */
+    public static void decryptUsingHsm(final Element encryptedDataElement, final HSM hsm,
+            final Collection<String> allowedKeyTransportAlgorithms) {
         try {
             validateEncryptedData(encryptedDataElement);
 
@@ -1274,9 +1316,18 @@ public final class Util {
             final NodeList encryptedKeyNodes =
                     ((Element) encryptedDataElement.getParentNode()).getElementsByTagNameNS(Constants.NS_XENC, "EncryptedKey");
             final EncryptedKey encryptedKey = xmlCipher.loadEncryptedKey((Element) encryptedKeyNodes.item(0));
+
+            final String keyTransportAlgorithm = encryptedKey.getEncryptionMethod().getAlgorithm();
+            if (keyTransportAlgorithm != null && !isKeyTransportAlgorithmAllowed(keyTransportAlgorithm, allowedKeyTransportAlgorithms)) {
+                // Do not throw a distinct exception: an algorithm rejection must be indistinguishable
+                // from any other decryption failure (e.g. a wrong key) to avoid a new side channel.
+                LOGGER.warn("Failed to decrypt an element using HSM.");
+                return;
+            }
+
             final byte[] encryptedBytes = base64decoder(encryptedKey.getCipherData().getCipherValue().getValue());
 
-            final byte[] decryptedKey = hsm.unwrapKey(encryptedKey.getEncryptionMethod().getAlgorithm(), encryptedBytes);
+            final byte[] decryptedKey = hsm.unwrapKey(keyTransportAlgorithm, encryptedBytes);
 
             final SecretKey encryptionKey = new SecretKeySpec(decryptedKey, 0, decryptedKey.length, "AES");
 
@@ -1286,6 +1337,57 @@ public final class Util {
         } catch (final Exception e) {
             LOGGER.warn("Failed to decrypt an element using HSM.", e);
         }
+    }
+
+    /**
+     * Locates the key transport (key wrapping) algorithm URI declared on the {@code xenc:EncryptedKey}
+     * associated with the given encrypted data element, looking first inside the element itself
+     * (e.g. inside its {@code KeyInfo}) and, if not found there, inside its parent node - mirroring
+     * how {@link #decryptUsingHsm(Element, HSM, Collection)} locates the {@code EncryptedKey}.
+     *
+     * @param encryptedDataElement The encrypted element.
+     *
+     * @return the key transport algorithm URI, or {@code null} if it could not be determined.
+     */
+    private static String findKeyTransportAlgorithm(final Element encryptedDataElement) {
+        try {
+            NodeList encryptedKeyNodes = encryptedDataElement.getElementsByTagNameNS(Constants.NS_XENC, "EncryptedKey");
+            if (encryptedKeyNodes.getLength() == 0 && encryptedDataElement.getParentNode() instanceof Element) {
+                encryptedKeyNodes =
+                        ((Element) encryptedDataElement.getParentNode()).getElementsByTagNameNS(Constants.NS_XENC, "EncryptedKey");
+            }
+            if (encryptedKeyNodes.getLength() > 0) {
+                final Element encryptedKeyElem = (Element) encryptedKeyNodes.item(0);
+                final NodeList encryptionMethodNodes = encryptedKeyElem.getElementsByTagNameNS(Constants.NS_XENC, "EncryptionMethod");
+                if (encryptionMethodNodes.getLength() > 0) {
+                    final String alg = ((Element) encryptionMethodNodes.item(0)).getAttribute("Algorithm");
+                    if (alg != null && !alg.isEmpty()) {
+                        return alg;
+                    }
+                }
+            }
+        } catch (final Exception e) {
+            // Best effort only; if the algorithm cannot be determined, the caller proceeds permissively.
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether a key transport (key wrapping) algorithm URI is allowed by an optional allow-list.
+     *
+     * @param algorithmUri
+     * 				 The key transport algorithm URI to check.
+     * @param allowedAlgorithms
+     * 				 The set of allowed key transport algorithm URIs. If {@code null} or empty, every
+     * 				 algorithm is considered allowed (permissive default).
+     *
+     * @return {@code true} if the algorithm is allowed, {@code false} otherwise.
+     */
+    public static boolean isKeyTransportAlgorithmAllowed(final String algorithmUri, final Collection<String> allowedAlgorithms) {
+        if (allowedAlgorithms == null || allowedAlgorithms.isEmpty()) {
+            return true;
+        }
+        return algorithmUri != null && allowedAlgorithms.contains(algorithmUri);
     }
 
     /**
@@ -1668,6 +1770,30 @@ public final class Util {
      */
     public static String generateNameId(final String value, final String spnq, final String format, final String nq,
             final X509Certificate cert) {
+        return generateNameId(value, spnq, format, nq, cert, null);
+    }
+
+    /**
+     * Generates a nameID.
+     *
+     * @param value
+     * 				 The value
+     * @param spnq
+     * 				 SP Name Qualifier
+     * @param format
+     * 				 SP Format
+     * @param nq
+     * 				 Name Qualifier
+     * @param cert
+     * 				 IdP Public certificate to encrypt the nameID
+     * @param keyTransportAlgorithm
+     * 				 The key transport (key wrapping) algorithm URI used to encrypt the symmetric key.
+     * 				 If {@code null} or empty, {@link Constants#RSA_1_5} is used, preserving the historical default.
+     *
+     * @return Xml contained in the document.
+     */
+    public static String generateNameId(final String value, final String spnq, final String format, final String nq,
+            final X509Certificate cert, final String keyTransportAlgorithm) {
         String res = null;
         try {
             final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -1697,7 +1823,9 @@ public final class Util {
                 xmlCipher.init(XMLCipher.ENCRYPT_MODE, symmetricKey);
 
                 // cipher for encrypt the symmetric key
-                final XMLCipher keyCipher = XMLCipher.getInstance(Constants.RSA_1_5);
+                final String keyTransportAlg =
+                        (keyTransportAlgorithm != null && !keyTransportAlgorithm.isEmpty()) ? keyTransportAlgorithm : Constants.RSA_1_5;
+                final XMLCipher keyCipher = XMLCipher.getInstance(keyTransportAlg);
                 keyCipher.init(XMLCipher.WRAP_MODE, cert.getPublicKey());
 
                 // encrypt the symmetric key

--- a/core/src/test/java/org/codelibs/saml2/core/test/authn/AuthnResponseTest.java
+++ b/core/src/test/java/org/codelibs/saml2/core/test/authn/AuthnResponseTest.java
@@ -16,8 +16,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -28,11 +30,13 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.codelibs.saml2.core.authn.SamlResponse;
+import org.codelibs.saml2.core.exception.SAMLException;
 import org.codelibs.saml2.core.exception.SAMLSevereException;
 import org.codelibs.saml2.core.exception.SettingsException;
 import org.codelibs.saml2.core.exception.ValidationException;
 import org.codelibs.saml2.core.http.HttpRequest;
 import org.codelibs.saml2.core.model.SamlResponseStatus;
+import org.codelibs.saml2.core.replay.InMemoryReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.settings.SettingsBuilder;
 import org.codelibs.saml2.core.util.Constants;
@@ -163,6 +167,33 @@ public class AuthnResponseTest {
 
         expectedEx.expect(SettingsException.class);
         expectedEx.expectMessage("No private key available for decrypt, check settings");
+        new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+    }
+
+    /**
+     * Tests the constructor of SamlResponse
+     * Case: EncryptedAssertion whose decryption fails because the configured SP
+     * private key does not match the key the assertion was encrypted with.
+     * Util.decryptElement() swallows the underlying decryption exception, so
+     * decryptAssertion() must detect the missing decrypted saml:Assertion node
+     * and raise a typed ValidationException(MISSING_ENCRYPTED_ELEMENT) instead
+     * of letting a NullPointerException escape the constructor.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.authn.SamlResponse#decryptAssertion
+     */
+    @Test
+    public void testEncryptedAssertionWrongKeyThrowsValidationException() throws Exception {
+        // config.different.properties carries a SP private key that does NOT match
+        // the key used to encrypt data/responses/valid_encrypted_assertion.xml.base64
+        // (see UtilsTest#testDecryptElementAssertionWrongKey which uses the same key
+        // and proves decryption of this exact fixture fails).
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.different.properties").build();
+        String samlResponseEncoded = Util.getFileAsString("data/responses/valid_encrypted_assertion.xml.base64");
+
+        expectedEx.expect(ValidationException.class);
+        expectedEx.expectMessage("No /samlp:Response/saml:EncryptedAssertion/saml:Assertion element found");
         new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
     }
 
@@ -501,6 +532,74 @@ public class AuthnResponseTest {
         samlResponseEncoded = Util.getFileAsString("data/responses/invalids/no_nameid.xml.base64");
         samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
         assertTrue(samlResponse.getNameIdData().isEmpty());
+    }
+
+    /**
+     * Tests the getNameIdData method of SamlResponse with an allow-list of key transport algorithms.
+     * <p>
+     * Case: by default (no allow-list configured) decryption of a RSA_1_5-encrypted NameID is
+     * unaffected, matching the historical permissive behavior.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.authn.SamlResponse#getNameIdData
+     */
+    @Test
+    public void testGetNameIdDataDefaultAllowsAllKeyTransportAlgorithms() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+        assertNull(settings.getAllowedKeyTransportAlgorithms());
+
+        String samlResponseEncoded = Util.getFileAsString("data/responses/response_encrypted_nameid.xml.base64");
+        SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+        String nameIdDataStr = samlResponse.getNameIdData().toString();
+        assertThat(nameIdDataStr, containsString("Value=2de11defd199f8d5bb63f9b7deb265ba5c675c10"));
+    }
+
+    /**
+     * Tests the getNameIdData method of SamlResponse with an allow-list of key transport algorithms.
+     * <p>
+     * Case: the fixture is encrypted with RSA_1_5, but the allow-list only contains RSA_OAEP_MGF1P, so
+     * the NameID decryption must be rejected - surfacing as the same generic failure as any other
+     * decryption problem (e.g. a wrong key), not a new distinct exception type.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.authn.SamlResponse#getNameIdData
+     */
+    @Test
+    public void testGetNameIdDataRejectsDisallowedKeyTransportAlgorithm() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+        settings.setAllowedKeyTransportAlgorithms(new HashSet<>(Arrays.asList(Constants.RSA_OAEP_MGF1P)));
+
+        String samlResponseEncoded = Util.getFileAsString("data/responses/response_encrypted_nameid.xml.base64");
+        SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+
+        expectedEx.expect(SAMLException.class);
+        expectedEx.expectMessage("Not able to decrypt the EncryptedID and get a NameID");
+        samlResponse.getNameIdData();
+    }
+
+    /**
+     * Tests the decryptAssertion method of SamlResponse with an allow-list of key transport algorithms.
+     * <p>
+     * Case: the fixture is encrypted with RSA_1_5, but the allow-list only contains RSA_OAEP_MGF1P, so
+     * decryption of the EncryptedAssertion must be rejected the same way a wrong key would be - a
+     * generic ValidationException(MISSING_ENCRYPTED_ELEMENT), not a new distinct exception type.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.authn.SamlResponse#decryptAssertion
+     */
+    @Test
+    public void testDecryptAssertionRejectsDisallowedKeyTransportAlgorithm() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+        settings.setAllowedKeyTransportAlgorithms(new HashSet<>(Arrays.asList(Constants.RSA_OAEP_MGF1P)));
+
+        String samlResponseEncoded = Util.getFileAsString("data/responses/valid_encrypted_assertion.xml.base64");
+
+        expectedEx.expect(ValidationException.class);
+        expectedEx.expectMessage("No /samlp:Response/saml:EncryptedAssertion/saml:Assertion element found");
+        new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
     }
 
     /**
@@ -1542,6 +1641,36 @@ public class AuthnResponseTest {
 
     /**
      * Tests the validateTimestamps method of SamlResponse
+     * Case: Encrypted assertion whose (decrypted) Conditions element has expired.
+     * The raw pre-decryption document has no Conditions element at all (it is inside
+     * the ciphertext, see saml:Conditions NotOnOrAfter="2055-06-07T20:17:08Z" in
+     * data/responses/valid_encrypted_assertion.xml.base64), so validateTimestamps()
+     * must inspect getSAMLResponseDocument() (the decrypted document) instead of the
+     * raw samlResponseDocument. Moving "now" past that NotOnOrAfter proves the
+     * encrypted Conditions are actually being checked: before the fix this method
+     * always returned true regardless of the clock, because the raw document has no
+     * Conditions element to find.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.authn.SamlResponse#validateTimestamps
+     */
+    @Test
+    public void testValidateTimestampsEncryptedAssertionExpired() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+        String samlResponseEncoded = Util.getFileAsString("data/responses/valid_encrypted_assertion.xml.base64");
+        SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+
+        // Move "now" past the decrypted assertion's Conditions/@NotOnOrAfter (2055-06-07T20:17:08Z).
+        DateTimeTestUtils.setFixedDateTime("2056-01-01T00:00:00Z");
+
+        expectedEx.expect(ValidationException.class);
+        expectedEx.expectMessage("Could not validate timestamp: expired. Check system clock.");
+        samlResponse.validateTimestamps();
+    }
+
+    /**
+     * Tests the validateTimestamps method of SamlResponse
      *
      * @throws ValidationException
      * @throws SettingsException
@@ -2418,6 +2547,54 @@ public class AuthnResponseTest {
 
         assertFalse(samlResponse.isValid("invalidRequestId"));
         assertThat(samlResponse.getError(), containsString("The InResponseTo of the Response"));
+    }
+
+    /**
+     * Tests the isValid method of SamlResponse
+     * Case: a ReplayCache is configured and the same Assertion is validated twice
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.authn.SamlResponse#isValid
+     */
+    @Test
+    public void testIsInValidReplayedAssertionWithCache() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+        settings.setStrict(true);
+        settings.setReplayCache(new InMemoryReplayCache());
+        String samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
+
+        SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+        assertTrue(samlResponse.isValid());
+
+        SamlResponse replayedResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+        assertFalse(replayedResponse.isValid());
+        assertTrue(replayedResponse.getValidationException() instanceof ValidationException);
+        assertEquals(ValidationException.ASSERTION_REPLAYED,
+                ((ValidationException) replayedResponse.getValidationException()).getErrorCode());
+    }
+
+    /**
+     * Tests the isValid method of SamlResponse
+     * Case: no ReplayCache is configured (default) - validating the same Assertion
+     * multiple times must keep succeeding, proving default behavior is unchanged.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.authn.SamlResponse#isValid
+     */
+    @Test
+    public void testIsValidReplayedAssertionWithoutCacheIsUnaffected() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+        settings.setStrict(true);
+        assertNull(settings.getReplayCache());
+        String samlResponseEncoded = Util.getFileAsString("data/responses/valid_response.xml.base64");
+
+        SamlResponse samlResponse = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+        assertTrue(samlResponse.isValid());
+
+        SamlResponse sameResponseAgain = new SamlResponse(settings, newHttpRequest(samlResponseEncoded));
+        assertTrue(sameResponseAgain.isValid());
     }
 
     @Test

--- a/core/src/test/java/org/codelibs/saml2/core/test/logout/LogoutRequestTest.java
+++ b/core/src/test/java/org/codelibs/saml2/core/test/logout/LogoutRequestTest.java
@@ -17,18 +17,22 @@ import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.xml.xpath.XPathExpressionException;
 
 import org.apache.xml.security.exceptions.XMLSecurityException;
+import org.codelibs.saml2.core.exception.SAMLException;
 import org.codelibs.saml2.core.exception.SAMLSevereException;
 import org.codelibs.saml2.core.exception.SettingsException;
 import org.codelibs.saml2.core.exception.ValidationException;
 import org.codelibs.saml2.core.http.HttpRequest;
 import org.codelibs.saml2.core.logout.LogoutRequest;
 import org.codelibs.saml2.core.logout.LogoutRequestParams;
+import org.codelibs.saml2.core.replay.InMemoryReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.settings.SettingsBuilder;
 import org.codelibs.saml2.core.test.NaiveUrlEncoder;
@@ -341,6 +345,36 @@ public class LogoutRequestTest {
         assertThat(nameIdDataStr, containsString("Format=" + Constants.NAMEID_PERSISTENT));
         assertThat(nameIdDataStr, containsString("NameQualifier=" + settings.getIdpEntityId()));
         assertThat(nameIdDataStr, containsString("SPNameQualifier=" + settings.getSpEntityId()));
+    }
+
+    /**
+     * Tests the getNameIdData method of LogoutRequest with an allow-list of key transport algorithms.
+     * <p>
+     * Case: the fixture is encrypted with RSA_1_5. An allow-list containing RSA_1_5 still decrypts
+     * successfully (equivalent to the permissive default), while an OAEP-only allow-list rejects it
+     * the same way a wrong private key would - a generic "Not able to decrypt" failure, not a new
+     * distinct exception type.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.logout.LogoutRequest#getNameIdData
+     */
+    @Test
+    public void testGetNameIdDataWithAllowedKeyTransportAlgorithms() throws Exception {
+        String keyString = Util.getFileAsString("data/customPath/certs/sp.pem");
+        PrivateKey key = Util.loadPrivateKey(keyString);
+        String logoutRequestStr = Util.getFileAsString("data/logout_requests/logout_request_encrypted_nameid.xml");
+
+        // decryptElement mutates the DOM in place, so each attempt needs its own fresh Document.
+        Set<String> allowedKeyTransportAlgorithms = new HashSet<>(Arrays.asList(Constants.RSA_1_5));
+        String nameIdDataStr =
+                LogoutRequest.getNameIdData(Util.loadXML(logoutRequestStr), key, false, allowedKeyTransportAlgorithms).toString();
+        assertThat(nameIdDataStr, containsString("Value=ONELOGIN_9c86c4542ab9d6fce07f2f7fd335287b9b3cdf69"));
+
+        Set<String> oaepOnly = new HashSet<>(Arrays.asList(Constants.RSA_OAEP_MGF1P));
+        expectedEx.expect(SAMLException.class);
+        expectedEx.expectMessage("Not able to decrypt the EncryptedID and get a NameID");
+        LogoutRequest.getNameIdData(Util.loadXML(logoutRequestStr), key, false, oaepOnly);
     }
 
     /**
@@ -975,6 +1009,76 @@ public class LogoutRequestTest {
         logoutRequest = new LogoutRequest(settings, httpRequest);
         assertFalse(logoutRequest.isValid());
         assertEquals("In order to validate the sign on the Logout Request, the x509cert of the IdP is required", logoutRequest.getError());
+    }
+
+    /**
+     * Tests the isValid method of LogoutRequest
+     * Case: a ReplayCache is configured and the same LogoutRequest is validated twice
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.logout.LogoutRequest#isValid
+     */
+    @Test
+    public void testIsInValidReplayedWithCache() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+        settings.setStrict(true);
+        settings.setWantMessagesSigned(true);
+        settings.setReplayCache(new InMemoryReplayCache());
+
+        final String requestURL = "https://pitbulk.no-ip.org/newonelogin/demo1/index.php?sls";
+        String samlRequestEncoded =
+                "lVLBitswEP0Vo7tjWbJkSyReFkIhsN1tm6WHvQTZHmdFbUmVZLqfXzlpIS10oZdhGM17b96MtkHNk5MP9myX+AW+LxBi9jZPJsjLyw4t3kirgg7SqBmCjL083n98kGSDpfM22t5O6AbyPkKFAD5qa1B22O/QSWA+EFWPjCtaM6gBugrXHCo6Ut6UgvTV2DSkBoKyr+BDQu5QIkrwEBY4mBCViamEyyrHNCf4ueSScMnIC8r2yY02Kl5QrzG6IIvC6dgt07eNsbl2G+vPhYEf1sBkz9oUA8y2LLQZ4G3jXt1dmALKHm18Mk/+fozgk5YQNMciJ+UzKWV11Wq3q3l5mcq3/9YKenYTrL3FGkihB1fMENWgoloVt8Ut0ZX1Me3xsM+On9bk86ImPep1kv+xdKuBsg/Wzyq+f6u1ood8vLTK6JUJGkxE7WnsSDcQRirOKMc97TtWCgqU1ZyJBvM+RZbSrv/l5mrg6sbJI4T1kId1ye0JhoaQgYg+XT1dnilMSZO4uko1jPSYVF0luqQjrmR/4X8X//jC7U8=";
+        String relayState = "_1037fbc88ec82ce8e770b2bed1119747bb812a07e6";
+        String sigAlg = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        String signature =
+                "j/qDRTzgQw3cMDkkSkBOShqxi3t9qJxYnrADqwAECnJ3Y+iYgT33C0l/Vy3+ooQkFRyObYJqg9o7iIcMdgV6CXxpa6itVIUAI2VJewsMjzvJ4OdpePeSx7+/umVPKCfMvffsELlqo/UgxsyRZh8NMLej0ojCB7bUfIMKsiU7e0c=";
+
+        HttpRequest httpRequest = new HttpRequest(requestURL, (String) null).addParameter("SAMLRequest", samlRequestEncoded)
+                .addParameter("RelayState", relayState).addParameter("SigAlg", sigAlg).addParameter("Signature", signature);
+
+        LogoutRequest logoutRequest = new LogoutRequest(settings, httpRequest);
+        assertTrue(logoutRequest.isValid());
+
+        LogoutRequest replayedRequest = new LogoutRequest(settings, httpRequest);
+        assertFalse(replayedRequest.isValid());
+        assertTrue(replayedRequest.getValidationException() instanceof ValidationException);
+        assertEquals(ValidationException.MESSAGE_REPLAYED, ((ValidationException) replayedRequest.getValidationException()).getErrorCode());
+    }
+
+    /**
+     * Tests the isValid method of LogoutRequest
+     * Case: no ReplayCache is configured (default) - validating the same
+     * LogoutRequest multiple times must keep succeeding, proving default
+     * behavior is unchanged.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.logout.LogoutRequest#isValid
+     */
+    @Test
+    public void testIsValidReplayedWithoutCacheIsUnaffected() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+        settings.setStrict(true);
+        settings.setWantMessagesSigned(true);
+        assertNull(settings.getReplayCache());
+
+        final String requestURL = "https://pitbulk.no-ip.org/newonelogin/demo1/index.php?sls";
+        String samlRequestEncoded =
+                "lVLBitswEP0Vo7tjWbJkSyReFkIhsN1tm6WHvQTZHmdFbUmVZLqfXzlpIS10oZdhGM17b96MtkHNk5MP9myX+AW+LxBi9jZPJsjLyw4t3kirgg7SqBmCjL083n98kGSDpfM22t5O6AbyPkKFAD5qa1B22O/QSWA+EFWPjCtaM6gBugrXHCo6Ut6UgvTV2DSkBoKyr+BDQu5QIkrwEBY4mBCViamEyyrHNCf4ueSScMnIC8r2yY02Kl5QrzG6IIvC6dgt07eNsbl2G+vPhYEf1sBkz9oUA8y2LLQZ4G3jXt1dmALKHm18Mk/+fozgk5YQNMciJ+UzKWV11Wq3q3l5mcq3/9YKenYTrL3FGkihB1fMENWgoloVt8Ut0ZX1Me3xsM+On9bk86ImPep1kv+xdKuBsg/Wzyq+f6u1ood8vLTK6JUJGkxE7WnsSDcQRirOKMc97TtWCgqU1ZyJBvM+RZbSrv/l5mrg6sbJI4T1kId1ye0JhoaQgYg+XT1dnilMSZO4uko1jPSYVF0luqQjrmR/4X8X//jC7U8=";
+        String relayState = "_1037fbc88ec82ce8e770b2bed1119747bb812a07e6";
+        String sigAlg = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        String signature =
+                "j/qDRTzgQw3cMDkkSkBOShqxi3t9qJxYnrADqwAECnJ3Y+iYgT33C0l/Vy3+ooQkFRyObYJqg9o7iIcMdgV6CXxpa6itVIUAI2VJewsMjzvJ4OdpePeSx7+/umVPKCfMvffsELlqo/UgxsyRZh8NMLej0ojCB7bUfIMKsiU7e0c=";
+
+        HttpRequest httpRequest = new HttpRequest(requestURL, (String) null).addParameter("SAMLRequest", samlRequestEncoded)
+                .addParameter("RelayState", relayState).addParameter("SigAlg", sigAlg).addParameter("Signature", signature);
+
+        LogoutRequest logoutRequest = new LogoutRequest(settings, httpRequest);
+        assertTrue(logoutRequest.isValid());
+
+        LogoutRequest sameRequestAgain = new LogoutRequest(settings, httpRequest);
+        assertTrue(sameRequestAgain.isValid());
     }
 
     /**

--- a/core/src/test/java/org/codelibs/saml2/core/test/logout/LogoutResponseTest.java
+++ b/core/src/test/java/org/codelibs/saml2/core/test/logout/LogoutResponseTest.java
@@ -24,6 +24,7 @@ import org.codelibs.saml2.core.http.HttpRequest;
 import org.codelibs.saml2.core.logout.LogoutResponse;
 import org.codelibs.saml2.core.logout.LogoutResponseParams;
 import org.codelibs.saml2.core.model.SamlResponseStatus;
+import org.codelibs.saml2.core.replay.InMemoryReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.settings.SettingsBuilder;
 import org.codelibs.saml2.core.test.NaiveUrlEncoder;
@@ -698,6 +699,59 @@ public class LogoutResponseTest {
         settings.setStrict(false);
         logoutResponse = new LogoutResponse(settings, httpRequest);
         assertTrue(logoutResponse.isValid());
+    }
+
+    /**
+     * Tests the isValid method of LogoutResponse
+     * Case: a ReplayCache is configured and the same LogoutResponse is validated twice
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.logout.LogoutResponse#isValid
+     */
+    @Test
+    public void testIsInValidReplayedWithCache() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+        settings.setStrict(true);
+        settings.setReplayCache(new InMemoryReplayCache());
+        String samlResponseEncoded = Util.getFileAsString("data/logout_responses/logout_response_deflated.xml.base64");
+        String requestURL = "http://stuff.com/endpoints/endpoints/sls.php";
+        HttpRequest httpRequest = newHttpRequest(requestURL, samlResponseEncoded);
+
+        LogoutResponse logoutResponse = new LogoutResponse(settings, httpRequest);
+        assertTrue(logoutResponse.isValid());
+
+        LogoutResponse replayedResponse = new LogoutResponse(settings, httpRequest);
+        assertFalse(replayedResponse.isValid());
+        assertTrue(replayedResponse.getValidationException() instanceof ValidationException);
+        assertEquals(ValidationException.MESSAGE_REPLAYED,
+                ((ValidationException) replayedResponse.getValidationException()).getErrorCode());
+    }
+
+    /**
+     * Tests the isValid method of LogoutResponse
+     * Case: no ReplayCache is configured (default) - validating the same
+     * LogoutResponse multiple times must keep succeeding, proving default
+     * behavior is unchanged.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.logout.LogoutResponse#isValid
+     */
+    @Test
+    public void testIsValidReplayedWithoutCacheIsUnaffected() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.min.properties").build();
+        settings.setStrict(true);
+        assertNull(settings.getReplayCache());
+        String samlResponseEncoded = Util.getFileAsString("data/logout_responses/logout_response_deflated.xml.base64");
+        String requestURL = "http://stuff.com/endpoints/endpoints/sls.php";
+        HttpRequest httpRequest = newHttpRequest(requestURL, samlResponseEncoded);
+
+        LogoutResponse logoutResponse = new LogoutResponse(settings, httpRequest);
+        assertTrue(logoutResponse.isValid());
+
+        LogoutResponse sameResponseAgain = new LogoutResponse(settings, httpRequest);
+        assertTrue(sameResponseAgain.isValid());
     }
 
     @Test

--- a/core/src/test/java/org/codelibs/saml2/core/test/replay/InMemoryReplayCacheTest.java
+++ b/core/src/test/java/org/codelibs/saml2/core/test/replay/InMemoryReplayCacheTest.java
@@ -1,0 +1,112 @@
+package org.codelibs.saml2.core.test.replay;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.codelibs.saml2.core.replay.InMemoryReplayCache;
+import org.codelibs.saml2.core.replay.ReplayCache;
+import org.junit.Test;
+
+/**
+ * Tests for {@link InMemoryReplayCache}.
+ */
+public class InMemoryReplayCacheTest {
+
+    /**
+     * Tests the registerAndCheck method of InMemoryReplayCache
+     * Case: first registration of an id is not a replay
+     *
+     * @see org.codelibs.saml2.core.replay.InMemoryReplayCache#registerAndCheck
+     */
+    @Test
+    public void testFirstRegistrationIsNotReplay() {
+        final ReplayCache cache = new InMemoryReplayCache();
+        final boolean replay = cache.registerAndCheck("id-1", Instant.now().plusSeconds(300));
+        assertFalse(replay);
+    }
+
+    /**
+     * Tests the registerAndCheck method of InMemoryReplayCache
+     * Case: second registration of the same, still-valid id is a replay
+     *
+     * @see org.codelibs.saml2.core.replay.InMemoryReplayCache#registerAndCheck
+     */
+    @Test
+    public void testSecondRegistrationIsReplay() {
+        final ReplayCache cache = new InMemoryReplayCache();
+        final Instant expiresAt = Instant.now().plusSeconds(300);
+
+        assertFalse(cache.registerAndCheck("id-2", expiresAt));
+        assertTrue(cache.registerAndCheck("id-2", expiresAt));
+    }
+
+    /**
+     * Tests the registerAndCheck method of InMemoryReplayCache
+     * Case: an id whose previous entry already expired is treated as fresh
+     *
+     * @see org.codelibs.saml2.core.replay.InMemoryReplayCache#registerAndCheck
+     */
+    @Test
+    public void testExpiredEntryIsTreatedAsFresh() {
+        final ReplayCache cache = new InMemoryReplayCache();
+        final Instant pastExpiry = Instant.now().minusSeconds(10);
+
+        assertFalse(cache.registerAndCheck("id-3", pastExpiry));
+        // Previous entry already expired, so this is treated as a fresh registration, not a replay.
+        assertFalse(cache.registerAndCheck("id-3", Instant.now().plusSeconds(300)));
+        // Now that it has been freshly re-registered with a future expiry, a further call is a replay.
+        assertTrue(cache.registerAndCheck("id-3", Instant.now().plusSeconds(300)));
+    }
+
+    /**
+     * Tests the registerAndCheck method of InMemoryReplayCache
+     * Case: concurrent registration of the same id only allows a single caller to see "not a replay"
+     *
+     * @throws InterruptedException
+     *
+     * @see org.codelibs.saml2.core.replay.InMemoryReplayCache#registerAndCheck
+     */
+    @Test
+    public void testConcurrentRegistrationSmoke() throws InterruptedException {
+        final ReplayCache cache = new InMemoryReplayCache();
+        final int threadCount = 16;
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch ready = new CountDownLatch(threadCount);
+        final CountDownLatch start = new CountDownLatch(1);
+        final AtomicInteger firstUseCount = new AtomicInteger();
+        final Instant expiresAt = Instant.now().plusSeconds(300);
+
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    ready.countDown();
+                    try {
+                        start.await();
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    if (!cache.registerAndCheck("concurrent-id", expiresAt)) {
+                        firstUseCount.incrementAndGet();
+                    }
+                });
+            }
+            ready.await();
+            start.countDown();
+            executor.shutdown();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertEquals(1, firstUseCount.get());
+    }
+}

--- a/core/src/test/java/org/codelibs/saml2/core/test/settings/IdPMetadataParserTest.java
+++ b/core/src/test/java/org/codelibs/saml2/core/test/settings/IdPMetadataParserTest.java
@@ -1,12 +1,16 @@
 package org.codelibs.saml2.core.test.settings;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.net.URL;
+import java.security.cert.X509Certificate;
 import java.util.Map;
 
+import org.codelibs.saml2.core.exception.SAMLSignatureException;
 import org.codelibs.saml2.core.settings.IdPMetadataParser;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.settings.SettingsBuilder;
@@ -180,6 +184,66 @@ public class IdPMetadataParserTest {
         assertEquals(Util.loadCert((String) idpInfo.get(SettingsBuilder.IDP_X509CERT_PROPERTY_KEY)), Util.loadCert(
                 "MIIDGTCCAoKgAwIBAgIBATANBgkqhkiG9w0BAQUFADBnMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UEBwwMU2FudGEgTW9uaWNhMREwDwYDVQQKDAhPbmVMb2dpbjEZMBcGA1UEAwwQYXBwLm9uZWxvZ2luLmNvbTAeFw0xMzA2MDUxNzE2MjBaFw0xODA2MDUxNzE2MjBaMGcxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQHDAxTYW50YSBNb25pY2ExETAPBgNVBAoMCE9uZUxvZ2luMRkwFwYDVQQDDBBhcHAub25lbG9naW4uY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCsalDL15zSKeEGy9c0Hao7+G02x6k/MlZuCwEvkPKUcl9QF/q0584lta735hmiZSuWOFQDNQ4VT53VevjAhOtzLJOsa8wcZ+SA1s3j4bNcpUIAHltb4Az6NC7U2/LatfnwscOazEJnVsfL4aaBdpIHBFQ6Ed0StD0AfB6Ci0hURwIDAQABo4HUMIHRMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFHm3fLi+Q1zMc3guMyHy5AHdQvdgMIGRBgNVHSMEgYkwgYaAFHm3fLi+Q1zMc3guMyHy5AHdQvdgoWukaTBnMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UEBwwMU2FudGEgTW9uaWNhMREwDwYDVQQKDAhPbmVMb2dpbjEZMBcGA1UEAwwQYXBwLm9uZWxvZ2luLmNvbYIBATAOBgNVHQ8BAf8EBAMCBPAwDQYJKoZIhvcNAQEFBQADgYEANZvzlB1Aq84AdOvsn2XKxBB/PmNZLqnM1VWRPaNcvjafx7eHd5qayXFNQz+bOLujENmgAm5padbydG89SeefpOGcY2TMsVt0RUzxTnN3Zq5G6Ja2fAKOEX01ejdoPPMmStqqSw8k1wPUU8uLYJG5wmjf0rCb8RVaeAwMc+wcEIA="));
         assertEquals("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", idpInfo.get(SettingsBuilder.SP_NAMEIDFORMAT_PROPERTY_KEY));
+    }
+
+    /**
+     * Tests the parseXML(Document, String, String, String, String, X509Certificate) overload.
+     * Case Valid: the metadata is signed with the certificate passed in as the trusted signing cert.
+     *
+     * @see org.codelibs.saml2.core.core.settings.IdPMetadataParser#parseXML(Document, String, String, String, String, X509Certificate)
+     */
+    @Test
+    public void testParseXMLWithTrustedSigningCertValid() throws Exception {
+        X509Certificate correctCert = Util.loadCert(Util.getFileAsString("data/customPath/certs/sp.crt"));
+        Document signedMetadataDocument = Util
+                .parseXML(new InputSource(getClass().getClassLoader().getResourceAsStream("data/metadata/signed_metadata_settings1.xml")));
+
+        Map<String, Object> idpInfo = IdPMetadataParser.parseXML(signedMetadataDocument, null, null, Constants.BINDING_HTTP_REDIRECT,
+                Constants.BINDING_HTTP_REDIRECT, correctCert);
+        assertNotNull(idpInfo);
+    }
+
+    /**
+     * Tests the parseXML(Document, String, String, String, String, X509Certificate) overload.
+     * Case Invalid: the metadata is signed with a certificate different from the trusted signing cert
+     * passed in, so a SAMLSignatureException must be thrown.
+     *
+     * @see org.codelibs.saml2.core.core.settings.IdPMetadataParser#parseXML(Document, String, String, String, String, X509Certificate)
+     */
+    @Test
+    public void testParseXMLWithTrustedSigningCertInvalid() throws Exception {
+        X509Certificate wrongCert = Util.loadCert(Util.getFileAsString("certs/certificate1"));
+        Document signedMetadataDocument = Util
+                .parseXML(new InputSource(getClass().getClassLoader().getResourceAsStream("data/metadata/signed_metadata_settings1.xml")));
+
+        try {
+            IdPMetadataParser.parseXML(signedMetadataDocument, null, null, Constants.BINDING_HTTP_REDIRECT, Constants.BINDING_HTTP_REDIRECT,
+                    wrongCert);
+            fail("Expected a SAMLSignatureException to be thrown");
+        } catch (SAMLSignatureException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Tests the parseFileXML(String, X509Certificate) shorthand overload.
+     * Case Valid/Invalid: valid with the correct trusted cert, throws with a wrong cert.
+     *
+     * @see org.codelibs.saml2.core.core.settings.IdPMetadataParser#parseFileXML(String, X509Certificate)
+     */
+    @Test
+    public void testParseFileXMLWithTrustedSigningCert() throws Exception {
+        X509Certificate correctCert = Util.loadCert(Util.getFileAsString("data/customPath/certs/sp.crt"));
+        Map<String, Object> idpInfo = IdPMetadataParser.parseFileXML("data/metadata/signed_metadata_settings1.xml", correctCert);
+        assertNotNull(idpInfo);
+
+        X509Certificate wrongCert = Util.loadCert(Util.getFileAsString("certs/certificate1"));
+        try {
+            IdPMetadataParser.parseFileXML("data/metadata/signed_metadata_settings1.xml", wrongCert);
+            fail("Expected a SAMLSignatureException to be thrown");
+        } catch (SAMLSignatureException e) {
+            // expected
+        }
     }
 
     @Test

--- a/core/src/test/java/org/codelibs/saml2/core/test/settings/Saml2SettingsTest.java
+++ b/core/src/test/java/org/codelibs/saml2/core/test/settings/Saml2SettingsTest.java
@@ -9,8 +9,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.security.cert.X509Certificate;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.codelibs.saml2.core.exception.SAMLSevereException;
 import org.codelibs.saml2.core.model.hsm.AzureKeyVault;
@@ -506,6 +509,58 @@ public class Saml2SettingsTest {
     }
 
     /**
+     * Tests the validateMetadata(String, X509Certificate) overload of the Saml2Settings
+     * Case Valid: metadata signed with the certificate that is passed in for validation
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.settings.Saml2Settings#validateMetadata(String, X509Certificate)
+     */
+    @Test
+    public void testValidateMetadataSignatureValid() throws Exception {
+        String certString = Util.getFileAsString("data/customPath/certs/sp.crt");
+        X509Certificate cert = Util.loadCert(certString);
+        String signedMetadataStr = Util.getFileAsString("data/metadata/signed_metadata_settings1.xml");
+
+        List<String> errors = Saml2Settings.validateMetadata(signedMetadataStr, cert);
+        assertFalse(errors.contains("metadata_signature_invalid"));
+    }
+
+    /**
+     * Tests the validateMetadata(String, X509Certificate) overload of the Saml2Settings
+     * Case Invalid: metadata signed with a different certificate than the one passed in for validation
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.settings.Saml2Settings#validateMetadata(String, X509Certificate)
+     */
+    @Test
+    public void testValidateMetadataSignatureInvalid() throws Exception {
+        X509Certificate wrongCert = Util.loadCert(Util.getFileAsString("certs/certificate1"));
+        String signedMetadataStr = Util.getFileAsString("data/metadata/signed_metadata_settings1.xml");
+
+        List<String> errors = Saml2Settings.validateMetadata(signedMetadataStr, wrongCert);
+        assertTrue(errors.contains("metadata_signature_invalid"));
+    }
+
+    /**
+     * Tests that the single-argument validateMetadata(String) overload never performs signature
+     * validation and remains unchanged when fed unsigned metadata.
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.settings.Saml2Settings#validateMetadata(String)
+     */
+    @Test
+    public void testValidateMetadataValidUnsignedSingleArgUnchanged() throws Exception {
+        Saml2Settings settings = new SettingsBuilder().fromFile("config/config.all.properties").build();
+        String metadataStr = settings.getSPMetadata();
+
+        List<String> errors = Saml2Settings.validateMetadata(metadataStr);
+        assertTrue(errors.isEmpty());
+    }
+
+    /**
      * Tests that default signature algorithm is SHA-256 instead of deprecated SHA-1
      *
      * @see org.codelibs.saml2.core.core.settings.Saml2Settings#getSignatureAlgorithm
@@ -590,5 +645,44 @@ public class Saml2SettingsTest {
         // Test that it can be changed
         settings.setClockDrift(180L);
         assertEquals(180L, settings.getClockDrift());
+    }
+
+    /**
+     * Tests the getSecurityWarnings method of the Saml2Settings
+     * Case: weak security posture, all warnings expected
+     *
+     * @throws Exception
+     *
+     * @see org.codelibs.saml2.core.core.settings.Saml2Settings#getSecurityWarnings
+     */
+    @Test
+    public void testGetSecurityWarningsWeakPosture() throws Exception {
+        Map<String, Object> samlData = new HashMap<>();
+        samlData.put(SettingsBuilder.STRICT_PROPERTY_KEY, false);
+        samlData.put(SettingsBuilder.CERTFINGERPRINT_PROPERTY_KEY, "afe71c28ef740bc87425be13a2263d37971da1f9");
+        Saml2Settings settings = new SettingsBuilder().fromValues(samlData).build();
+
+        List<String> warnings = settings.getSecurityWarnings();
+        assertThat(warnings, hasItem("strict_mode_disabled"));
+        assertThat(warnings, hasItem("weak_fingerprint_algorithm"));
+        assertThat(warnings, hasItem("deprecated_signature_algorithms_not_rejected"));
+        assertThat(warnings, hasItem("assertions_and_messages_not_required_signed"));
+    }
+
+    /**
+     * Tests the getSecurityWarnings method of the Saml2Settings
+     * Case: hardened security posture, no warnings expected
+     *
+     * @see org.codelibs.saml2.core.core.settings.Saml2Settings#getSecurityWarnings
+     */
+    @Test
+    public void testGetSecurityWarningsHardenedPosture() {
+        Saml2Settings settings = new Saml2Settings();
+        settings.setStrict(true);
+        settings.setRejectDeprecatedAlg(true);
+        settings.setWantAssertionsSigned(true);
+
+        List<String> warnings = settings.getSecurityWarnings();
+        assertTrue(warnings.isEmpty());
     }
 }

--- a/core/src/test/java/org/codelibs/saml2/core/test/util/UtilsTest.java
+++ b/core/src/test/java/org/codelibs/saml2/core/test/util/UtilsTest.java
@@ -30,8 +30,12 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -1477,6 +1481,83 @@ public class UtilsTest {
     }
 
     /**
+     * Tests the decryptElement method with an allow-list of key transport algorithms.
+     * Case: the fixture is encrypted with RSA_1_5 and the allow-list contains RSA_1_5, so
+     * decryption proceeds as if no allow-list had been provided.
+     *
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws GeneralSecurityException
+     * @throws XPathExpressionException
+     *
+     * @see org.codelibs.saml2.core.core.util.Util#decryptElement
+     */
+    @Test
+    public void testDecryptElementNameIdWithAllowedKeyTransportAlgorithm()
+            throws URISyntaxException, IOException, GeneralSecurityException, XPathExpressionException {
+        String keyString = Util.getFileAsString("data/customPath/certs/sp.pem");
+        PrivateKey key = Util.loadPrivateKey(keyString);
+
+        String responseNameIdEnc = Util.base64decodedInflated(Util.getFileAsString("data/responses/response_encrypted_nameid.xml.base64"));
+        Document responseNameIdEncDoc = Util.loadXML(responseNameIdEnc);
+        NodeList EncryptedNameIdNodes = Util.query(responseNameIdEncDoc, ".//saml:EncryptedID");
+        NodeList EncryptedDataNodes = Util.query(responseNameIdEncDoc, "./xenc:EncryptedData", EncryptedNameIdNodes.item(0));
+        Element encryptedData = (Element) EncryptedDataNodes.item(0);
+        assertEquals("xenc:EncryptedData", encryptedData.getNodeName());
+
+        Set<String> allowedKeyTransportAlgorithms = new HashSet<>(Arrays.asList(Constants.RSA_1_5));
+        Util.decryptElement(encryptedData, key, allowedKeyTransportAlgorithms);
+        assertEquals("saml:NameID", EncryptedNameIdNodes.item(0).getFirstChild().getNodeName());
+    }
+
+    /**
+     * Tests the decryptElement method with an allow-list of key transport algorithms.
+     * Case: the fixture is encrypted with RSA_1_5 but the allow-list only contains
+     * RSA_OAEP_MGF1P, so decryption must be rejected the same way a wrong key would be:
+     * no exception is thrown, the element is simply left encrypted.
+     *
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws GeneralSecurityException
+     * @throws XPathExpressionException
+     *
+     * @see org.codelibs.saml2.core.core.util.Util#decryptElement
+     */
+    @Test
+    public void testDecryptElementNameIdWithDisallowedKeyTransportAlgorithm()
+            throws URISyntaxException, IOException, GeneralSecurityException, XPathExpressionException {
+        String keyString = Util.getFileAsString("data/customPath/certs/sp.pem");
+        PrivateKey key = Util.loadPrivateKey(keyString);
+
+        String responseNameIdEnc = Util.base64decodedInflated(Util.getFileAsString("data/responses/response_encrypted_nameid.xml.base64"));
+        Document responseNameIdEncDoc = Util.loadXML(responseNameIdEnc);
+        NodeList EncryptedNameIdNodes = Util.query(responseNameIdEncDoc, ".//saml:EncryptedID");
+        NodeList EncryptedDataNodes = Util.query(responseNameIdEncDoc, "./xenc:EncryptedData", EncryptedNameIdNodes.item(0));
+        Element encryptedData = (Element) EncryptedDataNodes.item(0);
+        assertEquals("xenc:EncryptedData", encryptedData.getNodeName());
+
+        Set<String> allowedKeyTransportAlgorithms = new HashSet<>(Arrays.asList(Constants.RSA_OAEP_MGF1P));
+        Util.decryptElement(encryptedData, key, allowedKeyTransportAlgorithms);
+        assertNotEquals("saml:NameID", EncryptedNameIdNodes.item(0).getFirstChild().getNodeName());
+        assertEquals("xenc:EncryptedData", EncryptedNameIdNodes.item(0).getFirstChild().getNodeName());
+    }
+
+    /**
+     * Tests the isKeyTransportAlgorithmAllowed method
+     *
+     * @see org.codelibs.saml2.core.core.util.Util#isKeyTransportAlgorithmAllowed
+     */
+    @Test
+    public void testIsKeyTransportAlgorithmAllowed() {
+        assertTrue(Util.isKeyTransportAlgorithmAllowed(Constants.RSA_1_5, null));
+        assertTrue(Util.isKeyTransportAlgorithmAllowed(Constants.RSA_1_5, Collections.emptySet()));
+
+        Set<String> allowedKeyTransportAlgorithms = new HashSet<>(Arrays.asList(Constants.RSA_OAEP_MGF1P));
+        assertTrue(Util.isKeyTransportAlgorithmAllowed(Constants.RSA_OAEP_MGF1P, allowedKeyTransportAlgorithms));
+        assertFalse(Util.isKeyTransportAlgorithmAllowed(Constants.RSA_1_5, allowedKeyTransportAlgorithms));
+    }
+
+    /**
      * Tests the copyDocument method
      *
      * @throws IOException
@@ -1938,11 +2019,46 @@ public class UtilsTest {
     }
 
     /**
+     * Tests the generateNameId method with an explicit key transport algorithm.
+     * Case: default (5-arg overload) still uses RSA_1_5; explicit RSA_OAEP_MGF1P is honored.
+     *
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws CertificateException
+     *
+     * @see org.codelibs.saml2.core.core.util.Util#generateNameId
+     */
+    @Test
+    public void testGenerateNameIdWithKeyTransportAlgorithm() throws URISyntaxException, IOException, CertificateException {
+        String nameIdValue = "ONELOGIN_ce998811003f4e60f8b07a311dc641621379cfde";
+        String entityId = "http://stuff.com/endpoints/metadata.php";
+        String nameIDFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+
+        String certString = Util.getFileAsString("data/customPath/certs/sp.crt");
+        X509Certificate cert = Util.loadCert(certString);
+
+        // Existing 5-arg overload keeps the default RSA_1_5 key transport algorithm.
+        String nameIdDefault = Util.generateNameId(nameIdValue, entityId, nameIDFormat, cert);
+        assertThat(nameIdDefault, containsString(Constants.RSA_1_5));
+        assertThat(nameIdDefault, not(containsString(Constants.RSA_OAEP_MGF1P)));
+
+        // New 6-arg overload with a null algorithm behaves exactly like the default.
+        String nameIdNullAlg = Util.generateNameId(nameIdValue, entityId, nameIDFormat, null, cert, null);
+        assertThat(nameIdNullAlg, containsString(Constants.RSA_1_5));
+
+        // New 6-arg overload honors an explicit key transport algorithm.
+        String nameIdOaep = Util.generateNameId(nameIdValue, entityId, nameIDFormat, null, cert, Constants.RSA_OAEP_MGF1P);
+        assertThat(nameIdOaep, containsString("<saml:EncryptedID><xenc:EncryptedData"));
+        assertThat(nameIdOaep, containsString(Constants.RSA_OAEP_MGF1P));
+        assertThat(nameIdOaep, not(containsString(Constants.RSA_1_5)));
+    }
+
+    /**
      * Tests the generateNameId method
      *
-     * @throws IOException 
-     * @throws URISyntaxException 
-     * @throws CertificateException 
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws CertificateException
      *
      * @see org.codelibs.saml2.core.core.util.Util#generateNameId
      */

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/acs.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/acs.jsp
@@ -65,6 +65,10 @@
 
 			String relayState = request.getParameter("RelayState");
 
+			// SECURITY WARNING: RelayState is attacker-controlled (it comes from an HTTP parameter).
+			// Redirecting to it verbatim is an open-redirect vulnerability. Validate it against an
+			// application-controlled allowlist, or restrict it to a known-safe relative path, before
+			// calling sendRedirect.
 			if (relayState != null && !relayState.isEmpty() && !relayState.equals(ServletUtils.getSelfRoutedURLNoQuery(request)) &&
 				!relayState.contains("/dologin.jsp")) { // We don't want to be redirected to login.jsp neither
 				response.sendRedirect(request.getParameter("RelayState"));

--- a/toolkit/src/main/java/org/codelibs/saml2/Auth.java
+++ b/toolkit/src/main/java/org/codelibs/saml2/Auth.java
@@ -26,6 +26,7 @@ import org.codelibs.saml2.core.logout.LogoutResponse;
 import org.codelibs.saml2.core.logout.LogoutResponseParams;
 import org.codelibs.saml2.core.model.KeyStoreSettings;
 import org.codelibs.saml2.core.model.SamlResponseStatus;
+import org.codelibs.saml2.core.replay.ReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.settings.SettingsBuilder;
 import org.codelibs.saml2.core.util.Constants;
@@ -291,6 +292,16 @@ public class Auth {
      */
     public void setStrict(final Boolean value) {
         settings.setStrict(value);
+    }
+
+    /**
+     * Sets the replay cache used to detect replayed SAML assertions and logout
+     * messages. When not set (the default), no replay checking is performed.
+     *
+     * @param cache the ReplayCache to be set
+     */
+    public void setReplayCache(final ReplayCache cache) {
+        settings.setReplayCache(cache);
     }
 
     /**

--- a/toolkit/src/test/java/org/codelibs/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/org/codelibs/saml2/test/AuthTest.java
@@ -51,6 +51,8 @@ import org.codelibs.saml2.core.logout.LogoutResponse;
 import org.codelibs.saml2.core.logout.LogoutResponseParams;
 import org.codelibs.saml2.core.model.KeyStoreSettings;
 import org.codelibs.saml2.core.model.SamlResponseStatus;
+import org.codelibs.saml2.core.replay.InMemoryReplayCache;
+import org.codelibs.saml2.core.replay.ReplayCache;
 import org.codelibs.saml2.core.settings.Saml2Settings;
 import org.codelibs.saml2.core.settings.SettingsBuilder;
 import org.codelibs.saml2.core.util.Constants;
@@ -357,6 +359,26 @@ public class AuthTest {
 
         auth.setStrict(true);
         assertTrue(auth.getSettings().isStrict());
+    }
+
+    /**
+     * Tests the setReplayCache method of Auth
+     *
+     * @throws SettingsException
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws Error
+     *
+     * @see org.codelibs.saml2.core.core.toolkit.Auth#setReplayCache
+     */
+    @Test
+    public void testSetReplayCache() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
+        Auth auth = new Auth();
+        assertNull(auth.getSettings().getReplayCache());
+
+        ReplayCache cache = new InMemoryReplayCache();
+        auth.setReplayCache(cache);
+        assertSame(cache, auth.getSettings().getReplayCache());
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in encrypted-assertion handling and adds several
backward-compatible, **opt-in** security controls surfaced by a security review
of the SP validation paths.

All changes are **additive**: no existing public method signature, default
value, or runtime behavior changes. Integrators see no difference unless they
explicitly opt in. Full test suite passes (**core 415, toolkit 92**).

## Bug fixes

- **`SamlResponse.decryptAssertion`** — a guard checked the wrong node list
  (`encryptedDataNodes`, already proven non-empty) instead of the
  post-decryption `AssertionDataNodes`. Because `Util.decryptElement` swallows
  decryption failures, a failed decryption left no `saml:Assertion`, and the
  code dereferenced `null`, throwing an **uncaught `NullPointerException` out of
  the `SamlResponse` constructor** (which `Auth.processResponse` does not wrap).
  It now raises a typed `ValidationException`.
- **`SamlResponse.validateTimestamps`** — it read the raw (pre-decryption)
  document, so for an **encrypted assertion** the `Conditions`
  (`NotBefore`/`NotOnOrAfter`) live inside the ciphertext, `getElementsByTagNameNS`
  matched nothing, and the temporal-validity window was **silently never
  checked**. It now reads the decrypted document like every other accessor.

## New opt-in security controls (defaults preserve current behavior)

- **Metadata signature validation** — wires the already-present (but previously
  unused) `Util.validateMetadataSign` into new overloads:
  `Saml2Settings.validateMetadata(xml, cert[, fingerprint, alg, rejectDeprecatedAlg])`
  and `IdPMetadataParser.parseXML/parseFileXML/parseRemoteXML(..., X509Certificate)`.
  Signature validation runs only when a trust anchor is supplied.
  > **Security note:** the trusted certificate **must be provisioned
  > out-of-band** (pinned config/keystore), not taken from the same metadata
  > document being validated — otherwise a MITM/compromised source can serve a
  > self-consistent forged document + cert. This is documented in the new
  > Javadoc.
- **Replay protection** — new `ReplayCache` SPI + thread-safe
  `InMemoryReplayCache` (TTL, no background threads). Enable with
  `auth.setReplayCache(new InMemoryReplayCache())` or
  `settings.setReplayCache(...)`. Detects replayed assertion IDs (SSO) and
  logout-message IDs (SLO); IDs are recorded only after a message is otherwise
  fully valid, so invalid messages cannot poison the cache. Default `null` =
  disabled (unchanged behavior).
- **RSA-OAEP key transport + inbound decrypt allow-list** — outbound NameID
  encryption algorithm is now selectable via
  `onelogin.saml2.security.nameid_encryption_algorithm` (default `rsa-1_5`,
  unchanged); an optional inbound allow-list
  `onelogin.saml2.security.allowed_key_transport_algorithms` (default empty =
  permissive) lets deployments reject legacy PKCS#1 v1.5 key transport. A
  rejected algorithm reuses the existing generic decryption-failure path, so it
  is indistinguishable from a wrong-key failure (no new padding-oracle side
  channel).
- **Configuration warnings** — `Saml2Settings.getSecurityWarnings()` reports
  weak-but-valid settings (strict off, weak fingerprint algorithm, deprecated
  algorithms not rejected, assertions/messages not required signed) and is
  logged at settings build time. `checkSettings()` is left unchanged.

## Docs

- Correct the "Security Defaults" note in `CLAUDE.md` (deprecated algorithms are
  **not** rejected by default; fingerprint default is `sha1`) and add production
  recommendations.
- Harden the `RelayState` redirect example in `README.md` and the JSP sample
  (fix a reference-equality guard and add an allow-list warning to prevent an
  open redirect in copied integration code).

## Backward compatibility

- Every new capability is reached through new overloads / new optional
  fields / new methods; existing callers and the ~27 tests that validate the
  same fixture multiple times pass unmodified.
- New settings default to the current behavior (RSA-1.5 outbound, permissive
  inbound, no replay cache, no metadata signature check).

## Testing

- TDD for every change (failing test confirmed first). New tests cover both bug
  reproductions, metadata signature validation, `getSecurityWarnings()`,
  RSA-OAEP output + allow-list rejection, `InMemoryReplayCache` (including a
  concurrency smoke test), and SSO/SLO replay detection.
- `mvn -B test`: **core 415, toolkit 92, 0 failures/errors**.
