### PR TITLE
Apply Java naming conventions and behavior-preserving idiom cleanup

### DIFF
--- a/core/src/main/java/org/codelibs/saml2/core/authn/AuthnRequest.java
+++ b/core/src/main/java/org/codelibs/saml2/core/authn/AuthnRequest.java
@@ -115,7 +115,7 @@ public class AuthnRequest {
 
         final StringSubstitutor substitutor = generateSubstitutor(params, settings);
         authnRequestString = postProcessXml(substitutor.replace(getAuthnRequestTemplate()), params, settings);
-        LOGGER.debug("AuthNRequest --> " + authnRequestString);
+        LOGGER.debug("AuthNRequest --> {}", authnRequestString);
     }
 
     /**
@@ -218,27 +218,27 @@ public class AuthnRequest {
         String subjectStr = "";
         final String nameIdValueReq = params.getNameIdValueReq();
         if (nameIdValueReq != null && !nameIdValueReq.isEmpty()) {
-            final String nameIDFormat = settings.getSpNameIDFormat();
+            final String nameIdFormat = settings.getSpNameIDFormat();
             subjectStr = "<saml:Subject>";
-            subjectStr += "<saml:NameID Format=\"" + Util.toXml(nameIDFormat) + "\">" + Util.toXml(nameIdValueReq) + "</saml:NameID>";
+            subjectStr += "<saml:NameID Format=\"" + Util.toXml(nameIdFormat) + "\">" + Util.toXml(nameIdValueReq) + "</saml:NameID>";
             subjectStr += "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"></saml:SubjectConfirmation>";
             subjectStr += "</saml:Subject>";
         }
         valueMap.put("subjectStr", subjectStr);
 
-        String nameIDPolicyStr = "";
+        String nameIdPolicyStr = "";
         if (params.isSetNameIdPolicy()) {
-            String nameIDPolicyFormat = settings.getSpNameIDFormat();
+            String nameIdPolicyFormat = settings.getSpNameIDFormat();
             if (settings.getWantNameIdEncrypted()) {
-                nameIDPolicyFormat = Constants.NAMEID_ENCRYPTED;
+                nameIdPolicyFormat = Constants.NAMEID_ENCRYPTED;
             }
             String allowCreateStr = "";
             if (params.isAllowCreate()) {
                 allowCreateStr = " AllowCreate=\"true\"";
             }
-            nameIDPolicyStr = "<samlp:NameIDPolicy Format=\"" + Util.toXml(nameIDPolicyFormat) + "\"" + allowCreateStr + " />";
+            nameIdPolicyStr = "<samlp:NameIDPolicy Format=\"" + Util.toXml(nameIdPolicyFormat) + "\"" + allowCreateStr + " />";
         }
-        valueMap.put("nameIDPolicyStr", nameIDPolicyStr);
+        valueMap.put("nameIDPolicyStr", nameIdPolicyStr);
 
         String providerStr = "";
         final Organization organization = settings.getOrganization();
@@ -252,7 +252,7 @@ public class AuthnRequest {
 
         final String issueInstantString = Util.formatDateTime(issueInstant.getTimeInMillis());
         valueMap.put("issueInstant", issueInstantString);
-        valueMap.put("id", Util.toXml(String.valueOf(id)));
+        valueMap.put("id", Util.toXml(id));
         valueMap.put("assertionConsumerServiceURL", Util.toXml(String.valueOf(settings.getSpAssertionConsumerServiceUrl())));
         valueMap.put("protocolBinding", Util.toXml(settings.getSpAssertionConsumerServiceBinding()));
         valueMap.put("spEntityid", Util.toXml(settings.getSpEntityId()));
@@ -261,12 +261,14 @@ public class AuthnRequest {
         final List<String> requestedAuthnContexts = settings.getRequestedAuthnContext();
         if (requestedAuthnContexts != null && !requestedAuthnContexts.isEmpty()) {
             final String requestedAuthnContextCmp = settings.getRequestedAuthnContextComparison();
-            requestedAuthnContextStr = "<samlp:RequestedAuthnContext Comparison=\"" + Util.toXml(requestedAuthnContextCmp) + "\">";
+            final StringBuilder requestedAuthnContextBuilder =
+                    new StringBuilder("<samlp:RequestedAuthnContext Comparison=\"" + Util.toXml(requestedAuthnContextCmp) + "\">");
             for (final String requestedAuthnContext : requestedAuthnContexts) {
-                requestedAuthnContextStr +=
-                        "<saml:AuthnContextClassRef>" + Util.toXml(requestedAuthnContext) + "</saml:AuthnContextClassRef>";
+                requestedAuthnContextBuilder.append("<saml:AuthnContextClassRef>").append(Util.toXml(requestedAuthnContext))
+                        .append("</saml:AuthnContextClassRef>");
             }
-            requestedAuthnContextStr += "</samlp:RequestedAuthnContext>";
+            requestedAuthnContextBuilder.append("</samlp:RequestedAuthnContext>");
+            requestedAuthnContextStr = requestedAuthnContextBuilder.toString();
         }
 
         valueMap.put("requestedAuthnContextStr", requestedAuthnContextStr);
@@ -277,13 +279,13 @@ public class AuthnRequest {
     /**
      * @return the AuthnRequest's template
      */
-    private static StringBuilder getAuthnRequestTemplate() {
+    private static String getAuthnRequestTemplate() {
         final StringBuilder template = new StringBuilder();
         template.append(
                 "<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"${id}\" Version=\"2.0\" IssueInstant=\"${issueInstant}\"${providerStr}${forceAuthnStr}${isPassiveStr}${destinationStr} ProtocolBinding=\"${protocolBinding}\" AssertionConsumerServiceURL=\"${assertionConsumerServiceURL}\">");
         template.append("<saml:Issuer>${spEntityid}</saml:Issuer>");
         template.append("${subjectStr}${nameIDPolicyStr}${requestedAuthnContextStr}</samlp:AuthnRequest>");
-        return template;
+        return template.toString();
     }
 
     /**

--- a/core/src/main/java/org/codelibs/saml2/core/authn/SamlResponse.java
+++ b/core/src/main/java/org/codelibs/saml2/core/authn/SamlResponse.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -350,7 +351,7 @@ public class SamlResponse {
                 if (expiresAt == null) {
                     final List<Instant> notOnOrAfters = getAssertionNotOnOrAfter();
                     expiresAt = notOnOrAfters.isEmpty() ? Instant.now().plusSeconds(settings.getClockDrift() + 300)
-                            : java.util.Collections.min(notOnOrAfters);
+                            : Collections.min(notOnOrAfters);
                 }
                 if (replayCache.registerAndCheck(assertionId, expiresAt)) {
                     throw new ValidationException("The Assertion was already processed (replay detected): " + assertionId,
@@ -389,24 +390,24 @@ public class SamlResponse {
 
             final NodeList subjectConfirmationDataNodes = scn.getChildNodes();
             for (int c = 0; c < subjectConfirmationDataNodes.getLength(); c++) {
-                if (subjectConfirmationDataNodes.item(c).getLocalName() != null
-                        && "SubjectConfirmationData".equals(subjectConfirmationDataNodes.item(c).getLocalName())) {
+                final Node subjectConfirmationDataNode = subjectConfirmationDataNodes.item(c);
+                if ("SubjectConfirmationData".equals(subjectConfirmationDataNode.getLocalName())) {
 
-                    final Node recipient = subjectConfirmationDataNodes.item(c).getAttributes().getNamedItem("Recipient");
+                    final Node recipient = subjectConfirmationDataNode.getAttributes().getNamedItem("Recipient");
                     final SubjectConfirmationIssue issue = validateRecipient(recipient, i);
                     if (issue != null) {
                         validationIssues.add(issue);
                         continue;
                     }
 
-                    final Node inResponseTo = subjectConfirmationDataNodes.item(c).getAttributes().getNamedItem("InResponseTo");
+                    final Node inResponseTo = subjectConfirmationDataNode.getAttributes().getNamedItem("InResponseTo");
                     if (inResponseTo == null && responseInResponseTo != null
                             || inResponseTo != null && !inResponseTo.getNodeValue().equals(responseInResponseTo)) {
                         validationIssues.add(new SubjectConfirmationIssue(i, "SubjectConfirmationData has an invalid InResponseTo value"));
                         continue;
                     }
 
-                    final Node notOnOrAfter = subjectConfirmationDataNodes.item(c).getAttributes().getNamedItem("NotOnOrAfter");
+                    final Node notOnOrAfter = subjectConfirmationDataNode.getAttributes().getNamedItem("NotOnOrAfter");
                     if (notOnOrAfter == null) {
                         validationIssues
                                 .add(new SubjectConfirmationIssue(i, "SubjectConfirmationData doesn't contain a NotOnOrAfter attribute"));
@@ -420,7 +421,7 @@ public class SamlResponse {
                         continue;
                     }
 
-                    final Node notBefore = subjectConfirmationDataNodes.item(c).getAttributes().getNamedItem("NotBefore");
+                    final Node notBefore = subjectConfirmationDataNode.getAttributes().getNamedItem("NotBefore");
                     if (notBefore != null) {
                         Instant nb = Util.parseDateTime(notBefore.getNodeValue());
                         nb = ChronoUnit.SECONDS.addTo(nb, settings.getClockDrift() * -1);
@@ -460,7 +461,7 @@ public class SamlResponse {
             return this.nameIdData;
         }
         try {
-            final Map<String, String> nameIdData = new HashMap<>();
+            final Map<String, String> data = new HashMap<>();
 
             final NodeList encryptedIDNodes = this.queryAssertion("/saml:Subject/saml:EncryptedID");
             NodeList nameIdNodes;
@@ -498,25 +499,25 @@ public class SamlResponse {
                         throw new ValidationException("An empty NameID value found", ValidationException.EMPTY_NAMEID);
                     }
 
-                    nameIdData.put("Value", value);
+                    data.put("Value", value);
 
                     if (nameIdElem.hasAttribute("Format")) {
-                        nameIdData.put("Format", nameIdElem.getAttribute("Format"));
+                        data.put("Format", nameIdElem.getAttribute("Format"));
                     }
                     if (nameIdElem.hasAttribute("SPNameQualifier")) {
                         final String spNameQualifier = nameIdElem.getAttribute("SPNameQualifier");
                         validateSpNameQualifier(spNameQualifier);
-                        nameIdData.put("SPNameQualifier", spNameQualifier);
+                        data.put("SPNameQualifier", spNameQualifier);
                     }
                     if (nameIdElem.hasAttribute("NameQualifier")) {
-                        nameIdData.put("NameQualifier", nameIdElem.getAttribute("NameQualifier"));
+                        data.put("NameQualifier", nameIdElem.getAttribute("NameQualifier"));
                     }
                 }
             } else if (settings.getWantNameId()) {
                 throw new ValidationException("No name id found in Document.", ValidationException.NO_NAMEID);
             }
-            this.nameIdData = nameIdData;
-            return nameIdData;
+            this.nameIdData = data;
+            return data;
         } catch (SAMLException e) {
             throw e;
         } catch (DOMException e) {
@@ -531,13 +532,13 @@ public class SamlResponse {
      *
      */
     public String getNameId() {
-        final Map<String, String> nameIdData = getNameIdData();
-        String nameID = null;
-        if (!nameIdData.isEmpty()) {
-            LOGGER.debug("SAMLResponse has NameID --> {}", nameIdData.get("Value"));
-            nameID = nameIdData.get("Value");
+        final Map<String, String> data = getNameIdData();
+        String nameId = null;
+        if (!data.isEmpty()) {
+            LOGGER.debug("SAMLResponse has NameID --> {}", data.get("Value"));
+            nameId = data.get("Value");
         }
-        return nameID;
+        return nameId;
     }
 
     /**
@@ -547,13 +548,13 @@ public class SamlResponse {
      *
      */
     public String getNameIdFormat() {
-        final Map<String, String> nameIdData = getNameIdData();
-        String nameidFormat = null;
-        if (!nameIdData.isEmpty() && nameIdData.containsKey("Format")) {
-            LOGGER.debug("SAMLResponse has NameID Format --> {}", nameIdData.get("Format"));
-            nameidFormat = nameIdData.get("Format");
+        final Map<String, String> data = getNameIdData();
+        String nameIdFormat = null;
+        if (!data.isEmpty() && data.containsKey("Format")) {
+            LOGGER.debug("SAMLResponse has NameID Format --> {}", data.get("Format"));
+            nameIdFormat = data.get("Format");
         }
-        return nameidFormat;
+        return nameIdFormat;
     }
 
     /**
@@ -563,11 +564,11 @@ public class SamlResponse {
      *
      */
     public String getNameIdNameQualifier() {
-        final Map<String, String> nameIdData = getNameIdData();
+        final Map<String, String> data = getNameIdData();
         String nameQualifier = null;
-        if (!nameIdData.isEmpty() && nameIdData.containsKey("NameQualifier")) {
-            LOGGER.debug("SAMLResponse has NameID NameQualifier --> " + nameIdData.get("NameQualifier"));
-            nameQualifier = nameIdData.get("NameQualifier");
+        if (!data.isEmpty() && data.containsKey("NameQualifier")) {
+            LOGGER.debug("SAMLResponse has NameID NameQualifier --> {}", data.get("NameQualifier"));
+            nameQualifier = data.get("NameQualifier");
         }
         return nameQualifier;
     }
@@ -579,11 +580,11 @@ public class SamlResponse {
      *
      */
     public String getNameIdSPNameQualifier() {
-        final Map<String, String> nameIdData = getNameIdData();
+        final Map<String, String> data = getNameIdData();
         String spNameQualifier = null;
-        if (!nameIdData.isEmpty() && nameIdData.containsKey("SPNameQualifier")) {
-            LOGGER.debug("SAMLResponse has NameID NameQualifier --> " + nameIdData.get("SPNameQualifier"));
-            spNameQualifier = nameIdData.get("SPNameQualifier");
+        if (!data.isEmpty() && data.containsKey("SPNameQualifier")) {
+            LOGGER.debug("SAMLResponse has NameID NameQualifier --> {}", data.get("SPNameQualifier"));
+            spNameQualifier = data.get("SPNameQualifier");
         }
         return spNameQualifier;
     }
@@ -609,7 +610,7 @@ public class SamlResponse {
                             ValidationException.DUPLICATED_ATTRIBUTE_NAME_FOUND);
                 }
 
-                final NodeList childrens = nodes.item(i).getChildNodes();
+                final NodeList children = nodes.item(i).getChildNodes();
 
                 List<String> attrValues = null;
                 if (attributes.containsKey(attName) && settings.isAllowRepeatAttributeName()) {
@@ -617,9 +618,9 @@ public class SamlResponse {
                 } else {
                     attrValues = new ArrayList<>();
                 }
-                for (int j = 0; j < childrens.getLength(); j++) {
-                    if ("AttributeValue".equals(childrens.item(j).getLocalName())) {
-                        String attrValue = childrens.item(j).getTextContent();
+                for (int j = 0; j < children.getLength(); j++) {
+                    if ("AttributeValue".equals(children.item(j).getLocalName())) {
+                        String attrValue = children.item(j).getTextContent();
                         if (attrValue != null && settings.isTrimAttributeValues()) {
                             attrValue = attrValue.trim();
                         }
@@ -629,7 +630,7 @@ public class SamlResponse {
 
                 attributes.put(attName, attrValues);
             }
-            LOGGER.debug("SAMLResponse has attributes: {}", attributes.toString());
+            LOGGER.debug("SAMLResponse has attributes: {}", attributes);
         } else {
             LOGGER.debug("SAMLResponse has no attributes");
         }
@@ -685,10 +686,7 @@ public class SamlResponse {
      */
     public Boolean checkOneCondition() {
         final NodeList entries = this.queryAssertion("/saml:Conditions");
-        if (entries.getLength() == 1) {
-            return true;
-        }
-        return false;
+        return entries.getLength() == 1;
     }
 
     /**
@@ -700,10 +698,7 @@ public class SamlResponse {
      */
     public Boolean checkOneAuthnStatement() {
         final NodeList entries = this.queryAssertion("/saml:AuthnStatement");
-        if (entries.getLength() == 1) {
-            return true;
-        }
-        return false;
+        return entries.getLength() == 1;
     }
 
     /**
@@ -933,8 +928,8 @@ public class SamlResponse {
      */
     public ArrayList<String> processSignedElements() {
         final ArrayList<String> signedElements = new ArrayList<>();
-        final ArrayList<String> verifiedSeis = new ArrayList<>();
-        final ArrayList<String> verifiedIds = new ArrayList<>();
+        final List<String> verifiedSeis = new ArrayList<>();
+        final List<String> verifiedIds = new ArrayList<>();
 
         final NodeList signNodes = query("//ds:Signature", null);
         for (int i = 0; i < signNodes.getLength(); i++) {
@@ -1011,7 +1006,7 @@ public class SamlResponse {
         final Map<String, Integer> occurrences = new HashMap<>();
         for (final String e : signedElements) {
             if (occurrences.containsKey(e)) {
-                occurrences.put(e, occurrences.get(e).intValue() + 1);
+                occurrences.put(e, occurrences.get(e) + 1);
             } else {
                 occurrences.put(e, 1);
             }
@@ -1027,7 +1022,7 @@ public class SamlResponse {
         }
 
         // check that the signed elements found here, are the ones that will be verified
-        // by org.codelibs.saml2.core.core.util.Util.validateSign()
+        // by org.codelibs.saml2.core.util.Util.validateSign()
         if (occurrences.containsKey(responseTag)) {
             final NodeList expectedSignatureNode = query(Util.RESPONSE_SIGNATURE_XPATH, null);
             if (expectedSignatureNode.getLength() != 1) {
@@ -1189,7 +1184,6 @@ public class SamlResponse {
      * @return DOMNodeList The queried nodes
      */
     protected NodeList query(final String nameQuery, final Node context) {
-        // LOGGER.debug("Executing query " + nameQuery);
         return Util.query(getSAMLResponseDocument(), nameQuery, context);
     }
 
@@ -1225,19 +1219,18 @@ public class SamlResponse {
         }
 
         // We need to Remove the saml:EncryptedAssertion Node
-        final NodeList AssertionDataNodes = Util.query(dom, "/samlp:Response/saml:EncryptedAssertion/saml:Assertion");
-        if (AssertionDataNodes.getLength() == 0) {
+        final NodeList assertionDataNodes = Util.query(dom, "/samlp:Response/saml:EncryptedAssertion/saml:Assertion");
+        if (assertionDataNodes.getLength() == 0) {
             throw new ValidationException("No /samlp:Response/saml:EncryptedAssertion/saml:Assertion element found",
                     ValidationException.MISSING_ENCRYPTED_ELEMENT);
         }
-        final Node assertionNode = AssertionDataNodes.item(0);
+        final Node assertionNode = assertionDataNodes.item(0);
         assertionNode.getParentNode().getParentNode().replaceChild(assertionNode, assertionNode.getParentNode());
 
         // In order to avoid Signature Validation errors we need to rebuild the dom.
         // https://groups.google.com/forum/#!topic/opensaml-users/gpXvwaZ53NA
         final String xmlStr = Util.convertDocumentToString(dom);
 
-        // LOGGER.debug("Decrypted SAMLResponse --> " + xmlStr);
         return Util.convertStringToDocument(xmlStr);
     }
 

--- a/core/src/main/java/org/codelibs/saml2/core/exception/InvalidKeySpecRuntimeException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/InvalidKeySpecRuntimeException.java
@@ -15,7 +15,7 @@ public class InvalidKeySpecRuntimeException extends RuntimeException {
      *
      * @param e the underlying invalid key spec exception
      */
-    public InvalidKeySpecRuntimeException(InvalidKeySpecException e) {
+    public InvalidKeySpecRuntimeException(final InvalidKeySpecException e) {
         super(e);
     }
 }

--- a/core/src/main/java/org/codelibs/saml2/core/exception/SAMLSignatureException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/SAMLSignatureException.java
@@ -13,7 +13,7 @@ public class SAMLSignatureException extends SAMLException {
      *
      * @param e the underlying exception
      */
-    public SAMLSignatureException(Exception e) {
+    public SAMLSignatureException(final Exception e) {
         super(e);
     }
 

--- a/core/src/main/java/org/codelibs/saml2/core/exception/X509CertificateException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/X509CertificateException.java
@@ -15,7 +15,7 @@ public class X509CertificateException extends SAMLException {
      *
      * @param e the underlying certificate exception
      */
-    public X509CertificateException(CertificateException e) {
+    public X509CertificateException(final CertificateException e) {
         super(e);
     }
 

--- a/core/src/main/java/org/codelibs/saml2/core/exception/XMLParsingException.java
+++ b/core/src/main/java/org/codelibs/saml2/core/exception/XMLParsingException.java
@@ -14,7 +14,7 @@ public class XMLParsingException extends SAMLException {
      * @param message the detail message
      * @param cause the underlying cause of the parsing failure
      */
-    public XMLParsingException(String message, Throwable cause) {
+    public XMLParsingException(final String message, final Throwable cause) {
         super(message, cause);
     }
 

--- a/core/src/main/java/org/codelibs/saml2/core/http/HttpRequest.java
+++ b/core/src/main/java/org/codelibs/saml2/core/http/HttpRequest.java
@@ -24,7 +24,7 @@ import org.codelibs.saml2.core.util.Util;
 public final class HttpRequest {
 
     /** An immutable empty map used as the default set of request parameters. */
-    public static final Map<String, List<String>> EMPTY_PARAMETERS = Collections.<String, List<String>> emptyMap();
+    public static final Map<String, List<String>> EMPTY_PARAMETERS = Collections.emptyMap();
 
     private final String requestURL;
     private final Map<String, List<String>> parameters;
@@ -87,7 +87,7 @@ public final class HttpRequest {
         checkNotNull(name, "name");
         checkNotNull(value, "value");
 
-        final List<String> oldValues = parameters.containsKey(name) ? parameters.get(name) : new ArrayList<>();
+        final List<String> oldValues = parameters.getOrDefault(name, new ArrayList<>());
         final List<String> newValues = new ArrayList<>(oldValues);
         newValues.add(value);
         final Map<String, List<String>> params = new HashMap<>(parameters);
@@ -140,7 +140,7 @@ public final class HttpRequest {
      */
     public List<String> getParameters(final String name) {
         final List<String> values = parameters.get(name);
-        return values != null ? values : Collections.<String> emptyList();
+        return values != null ? values : Collections.emptyList();
     }
 
     /**

--- a/core/src/main/java/org/codelibs/saml2/core/logout/LogoutRequest.java
+++ b/core/src/main/java/org/codelibs/saml2/core/logout/LogoutRequest.java
@@ -294,16 +294,10 @@ public class LogoutRequest {
      *
      */
     public String getEncodedLogoutRequest(Boolean deflated) {
-        String encodedLogoutRequest;
         if (deflated == null) {
             deflated = settings.isCompressRequestEnabled();
         }
-        if (deflated) {
-            encodedLogoutRequest = Util.deflatedBase64encoded(getLogoutRequestXml());
-        } else {
-            encodedLogoutRequest = Util.base64encoder(getLogoutRequestXml());
-        }
-        return encodedLogoutRequest;
+        return deflated ? Util.deflatedBase64encoded(getLogoutRequestXml()) : Util.base64encoder(getLogoutRequestXml());
     }
 
     /**
@@ -467,7 +461,7 @@ public class LogoutRequest {
                 // Check destination
                 if (rootElement.hasAttribute("Destination")) {
                     final String destinationUrl = rootElement.getAttribute("Destination");
-                    if ((destinationUrl != null) && (!destinationUrl.isEmpty() && !destinationUrl.equals(currentUrl))) {
+                    if (!destinationUrl.isEmpty() && !destinationUrl.equals(currentUrl)) {
                         throw new ValidationException("The LogoutRequest was received at " + currentUrl + " instead of " + destinationUrl,
                                 ValidationException.WRONG_DESTINATION);
                     }
@@ -494,7 +488,7 @@ public class LogoutRequest {
                 final List<X509Certificate> certList = new ArrayList<>();
                 final List<X509Certificate> multipleCertList = settings.getIdpx509certMulti();
 
-                if (multipleCertList != null && multipleCertList.size() != 0) {
+                if (multipleCertList != null && !multipleCertList.isEmpty()) {
                     certList.addAll(multipleCertList);
                 }
 
@@ -519,7 +513,7 @@ public class LogoutRequest {
 
                 final String relayState = request.getEncodedParameter("RelayState");
 
-                StringBuilder signedQuery = new StringBuilder("SAMLRequest=").append(request.getEncodedParameter("SAMLRequest"));
+                final StringBuilder signedQuery = new StringBuilder("SAMLRequest=").append(request.getEncodedParameter("SAMLRequest"));
 
                 if (relayState != null && !relayState.isEmpty()) {
                     signedQuery.append("&RelayState=").append(relayState);
@@ -679,8 +673,7 @@ public class LogoutRequest {
             final boolean trimValue, final Collection<String> allowedKeyTransportAlgorithms) {
         try {
             final NodeList encryptedIDNodes = Util.query(samlLogoutRequestDocument, "/samlp:LogoutRequest/saml:EncryptedID");
-            NodeList nameIdNodes;
-            Element nameIdElem;
+            final NodeList nameIdNodes;
 
             if (encryptedIDNodes.getLength() == 1) {
                 if (key == null) {
@@ -701,31 +694,29 @@ public class LogoutRequest {
             if ((nameIdNodes == null) || (nameIdNodes.getLength() != 1)) {
                 throw new ValidationException("No name id found in Logout Request.", ValidationException.NO_NAMEID);
             }
-            nameIdElem = (Element) nameIdNodes.item(0);
+            final Element nameIdElem = (Element) nameIdNodes.item(0);
 
             final Map<String, String> nameIdData = new HashMap<>();
 
-            if (nameIdElem != null) {
-                String value = nameIdElem.getTextContent();
-                if (value != null && trimValue) {
-                    value = value.trim();
-                }
-                nameIdData.put("Value", value);
+            String value = nameIdElem.getTextContent();
+            if (value != null && trimValue) {
+                value = value.trim();
+            }
+            nameIdData.put("Value", value);
 
-                if (nameIdElem.hasAttribute("Format")) {
-                    nameIdData.put("Format", nameIdElem.getAttribute("Format"));
-                }
-                if (nameIdElem.hasAttribute("SPNameQualifier")) {
-                    nameIdData.put("SPNameQualifier", nameIdElem.getAttribute("SPNameQualifier"));
-                }
-                if (nameIdElem.hasAttribute("NameQualifier")) {
-                    nameIdData.put("NameQualifier", nameIdElem.getAttribute("NameQualifier"));
-                }
+            if (nameIdElem.hasAttribute("Format")) {
+                nameIdData.put("Format", nameIdElem.getAttribute("Format"));
+            }
+            if (nameIdElem.hasAttribute("SPNameQualifier")) {
+                nameIdData.put("SPNameQualifier", nameIdElem.getAttribute("SPNameQualifier"));
+            }
+            if (nameIdElem.hasAttribute("NameQualifier")) {
+                nameIdData.put("NameQualifier", nameIdElem.getAttribute("NameQualifier"));
             }
             return nameIdData;
-        } catch (SAMLException e) {
+        } catch (final SAMLException e) {
             throw e;
-        } catch (DOMException e) {
+        } catch (final DOMException e) {
             throw new XMLParsingException("Failed to get NameID Data.", e);
         }
     }

--- a/core/src/main/java/org/codelibs/saml2/core/logout/LogoutResponse.java
+++ b/core/src/main/java/org/codelibs/saml2/core/logout/LogoutResponse.java
@@ -134,16 +134,10 @@ public class LogoutResponse {
      *
      */
     public String getEncodedLogoutResponse(Boolean deflated) {
-        String encodedLogoutResponse;
         if (deflated == null) {
             deflated = settings.isCompressResponseEnabled();
         }
-        if (deflated) {
-            encodedLogoutResponse = Util.deflatedBase64encoded(getLogoutResponseXml());
-        } else {
-            encodedLogoutResponse = Util.base64encoder(getLogoutResponseXml());
-        }
-        return encodedLogoutResponse;
+        return deflated ? Util.deflatedBase64encoded(getLogoutResponseXml()) : Util.base64encoder(getLogoutResponseXml());
     }
 
     /**
@@ -171,13 +165,13 @@ public class LogoutResponse {
      * @return the ID of the Response
      */
     public String getId() {
-        String idvalue = null;
+        String idValue = null;
         if (id != null) {
-            idvalue = id;
+            idValue = id;
         } else if (logoutResponseDocument != null) {
-            idvalue = logoutResponseDocument.getDocumentElement().getAttributes().getNamedItem("ID").getNodeValue();
+            idValue = logoutResponseDocument.getDocumentElement().getAttributes().getNamedItem("ID").getNodeValue();
         }
-        return idvalue;
+        return idValue;
     }
 
     /**
@@ -256,7 +250,7 @@ public class LogoutResponse {
                 final List<X509Certificate> certList = new ArrayList<>();
                 final List<X509Certificate> multipleCertList = settings.getIdpx509certMulti();
 
-                if (multipleCertList != null && multipleCertList.size() != 0) {
+                if (multipleCertList != null && !multipleCertList.isEmpty()) {
                     certList.addAll(multipleCertList);
                 }
 
@@ -279,7 +273,7 @@ public class LogoutResponse {
                     return false;
                 }
 
-                StringBuilder signedQuery = new StringBuilder("SAMLResponse=").append(request.getEncodedParameter("SAMLResponse"));
+                final StringBuilder signedQuery = new StringBuilder("SAMLResponse=").append(request.getEncodedParameter("SAMLResponse"));
 
                 final String relayState = request.getEncodedParameter("RelayState");
                 if (relayState != null && !relayState.isEmpty()) {

--- a/core/src/main/java/org/codelibs/saml2/core/logout/LogoutResponseParams.java
+++ b/core/src/main/java/org/codelibs/saml2/core/logout/LogoutResponseParams.java
@@ -65,11 +65,11 @@ public class LogoutResponseParams {
      *              the response status; should not be <code>null</code>
      */
     public LogoutResponseParams(final String inResponseTo, final SamlResponseStatus responseStatus) {
-        this.inResponseTo = inResponseTo;
-        this.responseStatus = responseStatus;
         if (responseStatus == null) {
             throw new IllegalArgumentException("response status must not be null");
         }
+        this.inResponseTo = inResponseTo;
+        this.responseStatus = responseStatus;
     }
 
     /**

--- a/core/src/main/java/org/codelibs/saml2/core/model/Contact.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/Contact.java
@@ -28,7 +28,7 @@ public class Contact {
     /**
      * Contact surname
      */
-    private final String surName;
+    private final String surname;
 
     /**
        * Contact email
@@ -80,7 +80,7 @@ public class Contact {
         this.contactType = contactType != null ? contactType : "";
         this.company = company;
         this.givenName = givenName;
-        this.surName = surName;
+        this.surname = surName;
         this.emailAddresses = emailAddresses != null ? emailAddresses : Collections.emptyList();
         this.telephoneNumbers = telephoneNumbers != null ? telephoneNumbers : Collections.emptyList();
     }
@@ -102,7 +102,7 @@ public class Contact {
      */
     @Deprecated
     public final String getEmailAddress() {
-        return emailAddresses.size() > 0 ? emailAddresses.get(0) : null;
+        return !emailAddresses.isEmpty() ? emailAddresses.get(0) : null;
     }
 
     /**
@@ -129,7 +129,7 @@ public class Contact {
      * @return the contact surname
      */
     public final String getSurName() {
-        return surName;
+        return surname;
     }
 
     /**

--- a/core/src/main/java/org/codelibs/saml2/core/model/RequestedAttribute.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/RequestedAttribute.java
@@ -68,7 +68,7 @@ public class RequestedAttribute {
     /**
      * Returns the RequestedAttribute friendly name.
      *
-     * @return string the RequestedAttribute fiendlyname
+     * @return string the RequestedAttribute friendlyName
      */
     public final String getFriendlyName() {
         return friendlyName;

--- a/core/src/main/java/org/codelibs/saml2/core/model/SubjectConfirmationIssue.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/SubjectConfirmationIssue.java
@@ -29,7 +29,7 @@ public class SubjectConfirmationIssue {
     public static String prettyPrintIssues(final List<SubjectConfirmationIssue> subjectConfirmationDataIssues) {
         final StringBuilder subjectConfirmationDataIssuesMsg =
                 new StringBuilder("A valid SubjectConfirmation was not found on this Response");
-        if (subjectConfirmationDataIssues.size() > 0) {
+        if (!subjectConfirmationDataIssues.isEmpty()) {
             subjectConfirmationDataIssuesMsg.append(": ");
         }
         for (int i = 0; i < subjectConfirmationDataIssues.size(); i++) {

--- a/core/src/main/java/org/codelibs/saml2/core/model/hsm/AzureKeyVault.java
+++ b/core/src/main/java/org/codelibs/saml2/core/model/hsm/AzureKeyVault.java
@@ -1,6 +1,7 @@
 package org.codelibs.saml2.core.model.hsm;
 
 import java.util.HashMap;
+import java.util.Map;
 
 import org.codelibs.saml2.core.util.Constants;
 
@@ -23,7 +24,7 @@ public class AzureKeyVault extends HSM {
     private final String tenantId;
     private final String keyVaultId;
     private CryptographyClient akvClient;
-    private final HashMap<String, KeyWrapAlgorithm> algorithmMapping;
+    private final Map<String, KeyWrapAlgorithm> algorithmMapping;
 
     /**
      * Constructor to initialise an HSM object.
@@ -49,8 +50,8 @@ public class AzureKeyVault extends HSM {
      *
      * @return The algorithm mapping.
      */
-    private HashMap<String, KeyWrapAlgorithm> createAlgorithmMapping() {
-        final HashMap<String, KeyWrapAlgorithm> mapping = new HashMap<>();
+    private Map<String, KeyWrapAlgorithm> createAlgorithmMapping() {
+        final Map<String, KeyWrapAlgorithm> mapping = new HashMap<>();
 
         mapping.put(Constants.RSA_1_5, KeyWrapAlgorithm.RSA1_5);
         mapping.put(Constants.RSA_OAEP_MGF1P, KeyWrapAlgorithm.RSA_OAEP);

--- a/core/src/main/java/org/codelibs/saml2/core/settings/IdPMetadataParser.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/IdPMetadataParser.java
@@ -12,9 +12,8 @@ import org.codelibs.saml2.core.exception.SAMLSignatureException;
 import org.codelibs.saml2.core.exception.XMLParsingException;
 import org.codelibs.saml2.core.util.Constants;
 import org.codelibs.saml2.core.util.Util;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -41,11 +40,6 @@ import org.xml.sax.InputSource;
 public class IdPMetadataParser {
 
     /**
-     * Private property to construct a logger for this class.
-     */
-    private static final Logger LOGGER = LoggerFactory.getLogger(IdPMetadataParser.class);
-
-    /**
      * Default constructor.
      */
     public IdPMetadataParser() {
@@ -67,31 +61,32 @@ public class IdPMetadataParser {
      *
      * @return Mapped values with metadata info in Saml2Settings format
      */
-    public static Map<String, Object> parseXML(final Document xmlDocument, String entityId, final String desiredNameIdFormat,
+    public static Map<String, Object> parseXML(final Document xmlDocument, final String entityId, final String desiredNameIdFormat,
             final String desiredSSOBinding, final String desiredSLOBinding) {
         final Map<String, Object> metadataInfo = new LinkedHashMap<>();
 
-        String customIdPStr = "";
+        String customIdpStr = "";
         if (entityId != null && !entityId.isEmpty()) {
-            customIdPStr = "[@entityID=\"" + entityId + "\"]";
+            customIdpStr = "[@entityID=\"" + entityId + "\"]";
         }
 
-        final String idpDescryptorXPath = "//md:EntityDescriptor" + customIdPStr + "/md:IDPSSODescriptor";
+        final String idpDescriptorXPath = "//md:EntityDescriptor" + customIdpStr + "/md:IDPSSODescriptor";
 
-        final NodeList idpDescriptorNodes = Util.query(xmlDocument, idpDescryptorXPath);
+        final NodeList idpDescriptorNodes = Util.query(xmlDocument, idpDescriptorXPath);
 
         if (idpDescriptorNodes.getLength() > 0) {
 
             final Node idpDescriptorNode = idpDescriptorNodes.item(0);
-            if (entityId == null || entityId.isEmpty()) {
-                final Node entityIDNode = idpDescriptorNode.getParentNode().getAttributes().getNamedItem("entityID");
-                if (entityIDNode != null) {
-                    entityId = entityIDNode.getNodeValue();
+            String resolvedEntityId = entityId;
+            if (resolvedEntityId == null || resolvedEntityId.isEmpty()) {
+                final Node entityIdNode = idpDescriptorNode.getParentNode().getAttributes().getNamedItem("entityID");
+                if (entityIdNode != null) {
+                    resolvedEntityId = entityIdNode.getNodeValue();
                 }
             }
 
-            if (entityId != null && !entityId.isEmpty()) {
-                metadataInfo.put(SettingsBuilder.IDP_ENTITYID_PROPERTY_KEY, entityId);
+            if (resolvedEntityId != null && !resolvedEntityId.isEmpty()) {
+                metadataInfo.put(SettingsBuilder.IDP_ENTITYID_PROPERTY_KEY, resolvedEntityId);
             }
 
             NodeList ssoNodes =
@@ -100,10 +95,11 @@ public class IdPMetadataParser {
                 ssoNodes = Util.query(xmlDocument, "./md:SingleSignOnService", idpDescriptorNode);
             }
             if (ssoNodes.getLength() > 0) {
+                final NamedNodeMap ssoAttributes = ssoNodes.item(0).getAttributes();
                 metadataInfo.put(SettingsBuilder.IDP_SINGLE_SIGN_ON_SERVICE_URL_PROPERTY_KEY,
-                        ssoNodes.item(0).getAttributes().getNamedItem("Location").getNodeValue());
+                        ssoAttributes.getNamedItem("Location").getNodeValue());
                 metadataInfo.put(SettingsBuilder.IDP_SINGLE_SIGN_ON_SERVICE_BINDING_PROPERTY_KEY,
-                        ssoNodes.item(0).getAttributes().getNamedItem("Binding").getNodeValue());
+                        ssoAttributes.getNamedItem("Binding").getNodeValue());
             }
 
             NodeList sloNodes =
@@ -112,11 +108,12 @@ public class IdPMetadataParser {
                 sloNodes = Util.query(xmlDocument, "./md:SingleLogoutService", idpDescriptorNode);
             }
             if (sloNodes.getLength() > 0) {
+                final NamedNodeMap sloAttributes = sloNodes.item(0).getAttributes();
                 metadataInfo.put(SettingsBuilder.IDP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY,
-                        sloNodes.item(0).getAttributes().getNamedItem("Location").getNodeValue());
+                        sloAttributes.getNamedItem("Location").getNodeValue());
                 metadataInfo.put(SettingsBuilder.IDP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY,
-                        sloNodes.item(0).getAttributes().getNamedItem("Binding").getNodeValue());
-                final Node responseLocationNode = sloNodes.item(0).getAttributes().getNamedItem("ResponseLocation");
+                        sloAttributes.getNamedItem("Binding").getNodeValue());
+                final Node responseLocationNode = sloAttributes.getNamedItem("ResponseLocation");
                 if (responseLocationNode != null) {
                     metadataInfo.put(SettingsBuilder.IDP_SINGLE_LOGOUT_SERVICE_RESPONSE_URL_PROPERTY_KEY,
                             responseLocationNode.getNodeValue());
@@ -382,7 +379,7 @@ public class IdPMetadataParser {
         try (InputStream is = xmlURL.openStream()) {
             final Document xmlDocument = Util.parseXML(new InputSource(is));
             return parseXML(xmlDocument, entityId, desiredNameIdFormat, desiredSSOBinding, desiredSLOBinding);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new XMLParsingException("Failed to parse a remote XML: " + xmlURL, e);
         }
     }
@@ -418,7 +415,7 @@ public class IdPMetadataParser {
         try (InputStream is = xmlURL.openStream()) {
             final Document xmlDocument = Util.parseXML(new InputSource(is));
             return parseXML(xmlDocument, entityId, desiredNameIdFormat, desiredSSOBinding, desiredSLOBinding, trustedSigningCert);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new XMLParsingException("Failed to parse a remote XML: " + xmlURL, e);
         }
     }

--- a/core/src/main/java/org/codelibs/saml2/core/settings/Metadata.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/Metadata.java
@@ -41,7 +41,7 @@ public class Metadata {
     /**
      * AttributeConsumingService
      */
-    private AttributeConsumingService attributeConsumingService = null;
+    private AttributeConsumingService attributeConsumingService;
 
     /**
      * Generated metadata in string format
@@ -143,7 +143,7 @@ public class Metadata {
     private StringSubstitutor generateSubstitutor(final Saml2Settings settings) {
 
         final Map<String, String> valueMap = new HashMap<>();
-        final Boolean wantsEncrypted = settings.getWantAssertionsEncrypted() || settings.getWantNameIdEncrypted();
+        final boolean wantsEncrypted = settings.getWantAssertionsEncrypted() || settings.getWantNameIdEncrypted();
 
         valueMap.put("id", Util.toXml(Util.generateUniqueID(settings.getUniqueIDPrefix())));
         String validUntilTimeStr = "";
@@ -170,7 +170,7 @@ public class Metadata {
 
         valueMap.put("strAttributeConsumingService", getAttributeConsumingServiceXml());
 
-        valueMap.put("strKeyDescriptor", toX509KeyDescriptorsXML(settings.getSPcert(), settings.getSPcertNew(), wantsEncrypted));
+        valueMap.put("strKeyDescriptor", toX509KeyDescriptorsXml(settings.getSPcert(), settings.getSPcertNew(), wantsEncrypted));
 
         valueMap.put("strContacts", toContactsXml(settings.getContacts()));
         valueMap.put("strOrganization", toOrganizationXml(settings.getOrganization()));
@@ -210,18 +210,18 @@ public class Metadata {
      * @return the AttributeConsumingService section of the metadata's template
      */
     private String getAttributeConsumingServiceXml() {
-        final StringBuilder attributeConsumingServiceXML = new StringBuilder();
+        final StringBuilder attributeConsumingServiceXml = new StringBuilder();
         if (attributeConsumingService != null) {
             final String serviceName = attributeConsumingService.getServiceName();
             final String serviceDescription = attributeConsumingService.getServiceDescription();
             final List<RequestedAttribute> requestedAttributes = attributeConsumingService.getRequestedAttributes();
 
-            attributeConsumingServiceXML.append("<md:AttributeConsumingService index=\"1\">");
+            attributeConsumingServiceXml.append("<md:AttributeConsumingService index=\"1\">");
             if (serviceName != null && !serviceName.isEmpty()) {
-                attributeConsumingServiceXML.append("<md:ServiceName xml:lang=\"en\">" + Util.toXml(serviceName) + "</md:ServiceName>");
+                attributeConsumingServiceXml.append("<md:ServiceName xml:lang=\"en\">" + Util.toXml(serviceName) + "</md:ServiceName>");
             }
             if (serviceDescription != null && !serviceDescription.isEmpty()) {
-                attributeConsumingServiceXML
+                attributeConsumingServiceXml
                         .append("<md:ServiceDescription xml:lang=\"en\">" + Util.toXml(serviceDescription) + "</md:ServiceDescription>");
             }
             if (requestedAttributes != null && !requestedAttributes.isEmpty()) {
@@ -232,40 +232,41 @@ public class Metadata {
                     final Boolean isRequired = requestedAttribute.isRequired();
                     final List<String> attrValues = requestedAttribute.getAttributeValues();
 
-                    String contentStr = "<md:RequestedAttribute";
+                    final StringBuilder contentStr = new StringBuilder("<md:RequestedAttribute");
 
                     if (name != null && !name.isEmpty()) {
-                        contentStr += " Name=\"" + Util.toXml(name) + "\"";
+                        contentStr.append(" Name=\"" + Util.toXml(name) + "\"");
                     }
 
                     if (nameFormat != null && !nameFormat.isEmpty()) {
-                        contentStr += " NameFormat=\"" + Util.toXml(nameFormat) + "\"";
+                        contentStr.append(" NameFormat=\"" + Util.toXml(nameFormat) + "\"");
                     }
 
                     if (friendlyName != null && !friendlyName.isEmpty()) {
-                        contentStr += " FriendlyName=\"" + Util.toXml(friendlyName) + "\"";
+                        contentStr.append(" FriendlyName=\"" + Util.toXml(friendlyName) + "\"");
                     }
 
                     if (isRequired != null) {
-                        contentStr += " isRequired=\"" + isRequired.toString() + "\"";
+                        contentStr.append(" isRequired=\"" + isRequired + "\"");
                     }
 
                     if (attrValues != null && !attrValues.isEmpty()) {
-                        contentStr += ">";
+                        contentStr.append(">");
                         for (final String attrValue : attrValues) {
-                            contentStr += "<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">"
-                                    + Util.toXml(attrValue) + "</saml:AttributeValue>";
+                            contentStr.append("<saml:AttributeValue xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">"
+                                    + Util.toXml(attrValue) + "</saml:AttributeValue>");
                         }
-                        attributeConsumingServiceXML.append(contentStr + "</md:RequestedAttribute>");
+                        contentStr.append("</md:RequestedAttribute>");
                     } else {
-                        attributeConsumingServiceXML.append(contentStr + " />");
+                        contentStr.append(" />");
                     }
+                    attributeConsumingServiceXml.append(contentStr);
                 }
             }
-            attributeConsumingServiceXML.append("</md:AttributeConsumingService>");
+            attributeConsumingServiceXml.append("</md:AttributeConsumingService>");
         }
 
-        return attributeConsumingServiceXML.toString();
+        return attributeConsumingServiceXml.toString();
     }
 
     /**
@@ -329,13 +330,13 @@ public class Metadata {
      *
      * @return the KeyDescriptor section of the metadata's template
      */
-    private String toX509KeyDescriptorsXML(final X509Certificate certCurrent, final X509Certificate certNew, final Boolean wantsEncrypted) {
+    private String toX509KeyDescriptorsXml(final X509Certificate certCurrent, final X509Certificate certNew, final boolean wantsEncrypted) {
         final StringBuilder keyDescriptorXml = new StringBuilder();
 
+        final Base64 encoder = new Base64(64);
         final List<X509Certificate> certs = Arrays.asList(certCurrent, certNew);
         for (final X509Certificate cert : certs) {
             if (cert != null) {
-                final Base64 encoder = new Base64(64);
                 try {
                     final byte[] encodedCert = cert.getEncoded();
                     final String certString = new String(encoder.encode(encodedCert));

--- a/core/src/main/java/org/codelibs/saml2/core/settings/Saml2Settings.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/Saml2Settings.java
@@ -4,8 +4,6 @@ import java.net.URL;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -42,55 +40,55 @@ public class Saml2Settings {
 
     // Toolkit settings
     private boolean strict = true;
-    private boolean debug = false;
+    private boolean debug;
 
     // SP
     private String spEntityId = "";
-    private URL spAssertionConsumerServiceUrl = null;
+    private URL spAssertionConsumerServiceUrl;
     private String spAssertionConsumerServiceBinding = Constants.BINDING_HTTP_POST;
-    private URL spSingleLogoutServiceUrl = null;
+    private URL spSingleLogoutServiceUrl;
     private String spSingleLogoutServiceBinding = Constants.BINDING_HTTP_REDIRECT;
-    private String spNameIDFormat = Constants.NAMEID_UNSPECIFIED;
-    private X509Certificate spX509cert = null;
-    private X509Certificate spX509certNew = null;
-    private PrivateKey spPrivateKey = null;
-    private HSM hsm = null;
-    private ReplayCache replayCache = null;
+    private String spNameIdFormat = Constants.NAMEID_UNSPECIFIED;
+    private X509Certificate spX509Cert;
+    private X509Certificate spX509CertNew;
+    private PrivateKey spPrivateKey;
+    private HSM hsm;
+    private ReplayCache replayCache;
 
     // IdP
     private String idpEntityId = "";
-    private URL idpSingleSignOnServiceUrl = null;
+    private URL idpSingleSignOnServiceUrl;
     private String idpSingleSignOnServiceBinding = Constants.BINDING_HTTP_REDIRECT;
-    private URL idpSingleLogoutServiceUrl = null;
-    private URL idpSingleLogoutServiceResponseUrl = null;
+    private URL idpSingleLogoutServiceUrl;
+    private URL idpSingleLogoutServiceResponseUrl;
     private String idpSingleLogoutServiceBinding = Constants.BINDING_HTTP_REDIRECT;
-    private X509Certificate idpx509cert = null;
-    private List<X509Certificate> idpx509certMulti = null;
-    private String idpCertFingerprint = null;
+    private X509Certificate idpX509Cert;
+    private List<X509Certificate> idpX509CertMulti;
+    private String idpCertFingerprint;
     private String idpCertFingerprintAlgorithm = "sha1";
 
     // Security
-    private boolean nameIdEncrypted = false;
-    private boolean authnRequestsSigned = false;
-    private boolean logoutRequestSigned = false;
-    private boolean logoutResponseSigned = false;
-    private boolean wantMessagesSigned = false;
-    private boolean wantAssertionsSigned = false;
-    private boolean wantAssertionsEncrypted = false;
+    private boolean nameIdEncrypted;
+    private boolean authnRequestsSigned;
+    private boolean logoutRequestSigned;
+    private boolean logoutResponseSigned;
+    private boolean wantMessagesSigned;
+    private boolean wantAssertionsSigned;
+    private boolean wantAssertionsEncrypted;
     private boolean wantNameId = true;
-    private boolean wantNameIdEncrypted = false;
-    private boolean signMetadata = false;
+    private boolean wantNameIdEncrypted;
+    private boolean signMetadata;
     private List<String> requestedAuthnContext = new ArrayList<>();
     private String requestedAuthnContextComparison = "exact";
-    private boolean wantXMLValidation = true;
+    private boolean wantXmlValidation = true;
     private String signatureAlgorithm = Constants.RSA_SHA256;
     private String digestAlgorithm = Constants.SHA256;
     private String nameIdEncryptionAlgorithm = Constants.RSA_1_5;
-    private Set<String> allowedKeyTransportAlgorithms = null;
-    private boolean rejectUnsolicitedResponsesWithInResponseTo = false;
-    private boolean allowRepeatAttributeName = false;
-    private boolean rejectDeprecatedAlg = false;
-    private String uniqueIDPrefix = null;
+    private Set<String> allowedKeyTransportAlgorithms;
+    private boolean rejectUnsolicitedResponsesWithInResponseTo;
+    private boolean allowRepeatAttributeName;
+    private boolean rejectDeprecatedAlg;
+    private String uniqueIdPrefix;
     private long clockDrift = Constants.ALLOWED_CLOCK_DRIFT;
 
     // Compress
@@ -98,14 +96,14 @@ public class Saml2Settings {
     private boolean compressResponse = true;
 
     // Parsing
-    private boolean trimNameIds = false;
-    private boolean trimAttributeValues = false;
+    private boolean trimNameIds;
+    private boolean trimAttributeValues;
 
     // Misc
-    private List<Contact> contacts = new LinkedList<>();
-    private Organization organization = null;
+    private List<Contact> contacts = new ArrayList<>();
+    private Organization organization;
 
-    private boolean spValidationOnly = false;
+    private boolean spValidationOnly;
 
     /**
      * Returns whether strict mode is enabled.
@@ -164,10 +162,10 @@ public class Saml2Settings {
     /**
      * Returns the Service Provider NameID format.
      *
-     * @return the spNameIDFormat setting value
+     * @return the spNameIdFormat setting value
      */
     public final String getSpNameIDFormat() {
-        return spNameIDFormat;
+        return spNameIdFormat;
     }
 
     /**
@@ -191,19 +189,19 @@ public class Saml2Settings {
     /**
      * Returns the Service Provider X.509 certificate.
      *
-     * @return the spX509cert setting value
+     * @return the spX509Cert setting value
      */
     public final X509Certificate getSPcert() {
-        return spX509cert;
+        return spX509Cert;
     }
 
     /**
      * Returns the new Service Provider X.509 certificate used for certificate rollover.
      *
-     * @return the spX509certNew setting value
+     * @return the spX509CertNew setting value
      */
     public final X509Certificate getSPcertNew() {
-        return spX509certNew;
+        return spX509CertNew;
     }
 
     /**
@@ -276,10 +274,10 @@ public class Saml2Settings {
     /**
      * Returns the Identity Provider X.509 certificate.
      *
-     * @return the idpx509cert setting value
+     * @return the idpX509Cert setting value
      */
     public final X509Certificate getIdpx509cert() {
-        return idpx509cert;
+        return idpX509Cert;
     }
 
     /**
@@ -309,10 +307,10 @@ public class Saml2Settings {
     /**
      * Returns the list of additional Identity Provider X.509 certificates.
      *
-     * @return the idpx509certMulti setting value
+     * @return the idpX509CertMulti setting value
      */
     public List<X509Certificate> getIdpx509certMulti() {
-        return idpx509certMulti;
+        return idpX509CertMulti;
     }
 
     /**
@@ -435,10 +433,10 @@ public class Saml2Settings {
     /**
      * Returns whether XML schema validation is performed on SAML messages.
      *
-     * @return the wantXMLValidation setting value
+     * @return the wantXmlValidation setting value
      */
     public boolean getWantXMLValidation() {
-        return wantXMLValidation;
+        return wantXmlValidation;
     }
 
     /**
@@ -494,7 +492,7 @@ public class Saml2Settings {
      * @return Unique ID prefix
      */
     public String getUniqueIDPrefix() {
-        return this.uniqueIDPrefix;
+        return this.uniqueIdPrefix;
     }
 
     /**
@@ -641,7 +639,7 @@ public class Saml2Settings {
      *            the spNameIDFormat value to be set
      */
     protected final void setSpNameIDFormat(final String spNameIDFormat) {
-        this.spNameIDFormat = spNameIDFormat;
+        this.spNameIdFormat = spNameIDFormat;
     }
 
     /**
@@ -671,7 +669,7 @@ public class Saml2Settings {
      *            the spX509cert value to be set in X509Certificate format
      */
     protected final void setSpX509cert(final X509Certificate spX509cert) {
-        this.spX509cert = spX509cert;
+        this.spX509Cert = spX509cert;
     }
 
     /**
@@ -681,7 +679,7 @@ public class Saml2Settings {
      *            the spX509certNew value to be set in X509Certificate format
      */
     protected final void setSpX509certNew(final X509Certificate spX509certNew) {
-        this.spX509certNew = spX509certNew;
+        this.spX509CertNew = spX509certNew;
     }
 
     /**
@@ -701,7 +699,7 @@ public class Saml2Settings {
      *            the Unique ID prefix used when generating Unique ID
      */
     protected final void setUniqueIDPrefix(final String uniqueIDPrefix) {
-        this.uniqueIDPrefix = uniqueIDPrefix;
+        this.uniqueIdPrefix = uniqueIDPrefix;
     }
 
     /**
@@ -771,7 +769,7 @@ public class Saml2Settings {
      *            the idpX509cert value to be set in X509Certificate format
      */
     protected final void setIdpx509cert(final X509Certificate idpX509cert) {
-        this.idpx509cert = idpX509cert;
+        this.idpX509Cert = idpX509cert;
     }
 
     /**
@@ -811,7 +809,7 @@ public class Saml2Settings {
      * @param idpx509certMulti the idpx509certMulti to set
      */
     public void setIdpx509certMulti(final List<X509Certificate> idpx509certMulti) {
-        this.idpx509certMulti = idpx509certMulti;
+        this.idpX509CertMulti = idpx509certMulti;
     }
 
     /**
@@ -943,7 +941,7 @@ public class Saml2Settings {
      *            the wantXMLValidation value to be set. Based on it the SP will validate SAML messages against the XML scheme
      */
     public void setWantXMLValidation(final boolean wantXMLValidation) {
-        this.wantXMLValidation = wantXMLValidation;
+        this.wantXmlValidation = wantXMLValidation;
     }
 
     /**
@@ -1188,13 +1186,15 @@ public class Saml2Settings {
             LOGGER.warn(errorMsg);
         }
 
-        if (!checkIdpx509certRequired() && !checkRequired(this.getIdpCertFingerprint())) {
+        final boolean idpx509certRequired = checkIdpx509certRequired();
+
+        if (!idpx509certRequired && !checkRequired(this.getIdpCertFingerprint())) {
             errorMsg = "idp_cert_or_fingerprint_not_found_and_required";
             errors.add(errorMsg);
             LOGGER.warn(errorMsg);
         }
 
-        if (!checkIdpx509certRequired() && this.getNameIdEncrypted()) {
+        if (!idpx509certRequired && this.getNameIdEncrypted()) {
             errorMsg = "idp_cert_not_found_and_required";
             errors.add(errorMsg);
             LOGGER.warn(errorMsg);
@@ -1246,12 +1246,8 @@ public class Saml2Settings {
 
         final List<Contact> contacts = this.getContacts();
         if (!contacts.isEmpty()) {
-            final Set<String> validTypes = new HashSet<>();
-            validTypes.add(Constants.CONTACT_TYPE_TECHNICAL);
-            validTypes.add(Constants.CONTACT_TYPE_SUPPORT);
-            validTypes.add(Constants.CONTACT_TYPE_ADMINISTRATIVE);
-            validTypes.add(Constants.CONTACT_TYPE_BILLING);
-            validTypes.add(Constants.CONTACT_TYPE_OTHER);
+            final Set<String> validTypes = Set.of(Constants.CONTACT_TYPE_TECHNICAL, Constants.CONTACT_TYPE_SUPPORT,
+                    Constants.CONTACT_TYPE_ADMINISTRATIVE, Constants.CONTACT_TYPE_BILLING, Constants.CONTACT_TYPE_OTHER);
             for (final Contact contact : contacts) {
                 if (!validTypes.contains(contact.getContactType())) {
                     errorMsg = "contact_type_invalid";
@@ -1295,7 +1291,7 @@ public class Saml2Settings {
         final X509Certificate cert = getSPcert();
         final PrivateKey key = getSPkey();
 
-        return (cert != null && key != null);
+        return cert != null && key != null;
     }
 
     /**
@@ -1308,7 +1304,7 @@ public class Saml2Settings {
      * @return true if the SP settings are valid
      */
     private boolean checkRequired(final Object value) {
-        if ((value == null) || (value instanceof String s && s.isEmpty())) {
+        if (value == null || (value instanceof String s && s.isEmpty())) {
             return false;
         }
 
@@ -1344,12 +1340,11 @@ public class Saml2Settings {
      *
      */
     public String getSPMetadata() {
-        final Metadata metadataObj = new Metadata(this);
-        String metadataString = metadataObj.getMetadataString();
+        final Metadata metadata = new Metadata(this);
+        String metadataString = metadata.getMetadataString();
 
         // Check if must be signed
-        final boolean signMetadata = this.getSignMetadata();
-        if (signMetadata) {
+        if (getSignMetadata()) {
             // Note: Currently only SP privateKey/certificate are supported for metadata signing.
             // Future enhancement: Support signing with custom key/certificate pairs for more flexible
             // key management scenarios (e.g., separate metadata signing keys, key rotation).

--- a/core/src/main/java/org/codelibs/saml2/core/settings/SettingsBuilder.java
+++ b/core/src/main/java/org/codelibs/saml2/core/settings/SettingsBuilder.java
@@ -65,136 +65,136 @@ public class SettingsBuilder {
     /**
      * Saml2Settings object
      */
-    private Saml2Settings saml2Setting;
+    private Saml2Settings saml2Settings;
 
     /** Property key for the strict mode flag ({@code onelogin.saml2.strict}). */
-    public final static String STRICT_PROPERTY_KEY = "onelogin.saml2.strict";
+    public static final String STRICT_PROPERTY_KEY = "onelogin.saml2.strict";
     /** Property key for the debug mode flag ({@code onelogin.saml2.debug}). */
-    public final static String DEBUG_PROPERTY_KEY = "onelogin.saml2.debug";
+    public static final String DEBUG_PROPERTY_KEY = "onelogin.saml2.debug";
 
     // SP
     /** Property key for the SP entity ID ({@code onelogin.saml2.sp.entityid}). */
-    public final static String SP_ENTITYID_PROPERTY_KEY = "onelogin.saml2.sp.entityid";
+    public static final String SP_ENTITYID_PROPERTY_KEY = "onelogin.saml2.sp.entityid";
     /** Property key for the SP Assertion Consumer Service URL ({@code onelogin.saml2.sp.assertion_consumer_service.url}). */
-    public final static String SP_ASSERTION_CONSUMER_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.sp.assertion_consumer_service.url";
+    public static final String SP_ASSERTION_CONSUMER_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.sp.assertion_consumer_service.url";
     /** Property key for the SP Assertion Consumer Service binding ({@code onelogin.saml2.sp.assertion_consumer_service.binding}). */
-    public final static String SP_ASSERTION_CONSUMER_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.sp.assertion_consumer_service.binding";
+    public static final String SP_ASSERTION_CONSUMER_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.sp.assertion_consumer_service.binding";
     /** Property key for the SP Single Logout Service URL ({@code onelogin.saml2.sp.single_logout_service.url}). */
-    public final static String SP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.sp.single_logout_service.url";
+    public static final String SP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.sp.single_logout_service.url";
     /** Property key for the SP Single Logout Service binding ({@code onelogin.saml2.sp.single_logout_service.binding}). */
-    public final static String SP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.sp.single_logout_service.binding";
+    public static final String SP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.sp.single_logout_service.binding";
     /** Property key for the SP NameID format ({@code onelogin.saml2.sp.nameidformat}). */
-    public final static String SP_NAMEIDFORMAT_PROPERTY_KEY = "onelogin.saml2.sp.nameidformat";
+    public static final String SP_NAMEIDFORMAT_PROPERTY_KEY = "onelogin.saml2.sp.nameidformat";
 
     /** Property key for the SP X.509 certificate ({@code onelogin.saml2.sp.x509cert}). */
-    public final static String SP_X509CERT_PROPERTY_KEY = "onelogin.saml2.sp.x509cert";
+    public static final String SP_X509CERT_PROPERTY_KEY = "onelogin.saml2.sp.x509cert";
     /** Property key for the SP private key ({@code onelogin.saml2.sp.privatekey}). */
-    public final static String SP_PRIVATEKEY_PROPERTY_KEY = "onelogin.saml2.sp.privatekey";
+    public static final String SP_PRIVATEKEY_PROPERTY_KEY = "onelogin.saml2.sp.privatekey";
     /** Property key for the SP new X.509 certificate used during certificate rotation ({@code onelogin.saml2.sp.x509certNew}). */
-    public final static String SP_X509CERTNEW_PROPERTY_KEY = "onelogin.saml2.sp.x509certNew";
+    public static final String SP_X509CERTNEW_PROPERTY_KEY = "onelogin.saml2.sp.x509certNew";
 
     /** Property key prefix for SP contact entries ({@code onelogin.saml2.sp.contact}). */
-    public final static String SP_CONTACT_PROPERTY_KEY_PREFIX = "onelogin.saml2.sp.contact";
+    public static final String SP_CONTACT_PROPERTY_KEY_PREFIX = "onelogin.saml2.sp.contact";
     /** Property key suffix for the SP contact type ({@code contactType}). */
-    public final static String SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX = "contactType";
+    public static final String SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX = "contactType";
     /** Property key suffix for the SP contact company name ({@code company}). */
-    public final static String SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX = "company";
+    public static final String SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX = "company";
     /** Property key suffix for the SP contact given name ({@code given_name}). */
-    public final static String SP_CONTACT_GIVEN_NAME_PROPERTY_KEY_SUFFIX = "given_name";
+    public static final String SP_CONTACT_GIVEN_NAME_PROPERTY_KEY_SUFFIX = "given_name";
     /** Property key suffix for the SP contact surname ({@code sur_name}). */
-    public final static String SP_CONTACT_SUR_NAME_PROPERTY_KEY_SUFFIX = "sur_name";
+    public static final String SP_CONTACT_SUR_NAME_PROPERTY_KEY_SUFFIX = "sur_name";
     /** Property key prefix for the SP contact e-mail addresses ({@code email_address}). */
-    public final static String SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX = "email_address";
+    public static final String SP_CONTACT_EMAIL_ADDRESS_PROPERTY_KEY_PREFIX = "email_address";
     /** Property key prefix for the SP contact telephone numbers ({@code telephone_number}). */
-    public final static String SP_CONTACT_TELEPHONE_NUMBER_PROPERTY_KEY_PREFIX = "telephone_number";
+    public static final String SP_CONTACT_TELEPHONE_NUMBER_PROPERTY_KEY_PREFIX = "telephone_number";
 
     // KeyStore
     /** Property key for the KeyStore instance holding the SP keys ({@code onelogin.saml2.keystore.store}). */
-    public final static String KEYSTORE_KEY = "onelogin.saml2.keystore.store";
+    public static final String KEYSTORE_KEY = "onelogin.saml2.keystore.store";
     /** Property key for the KeyStore alias of the SP entry ({@code onelogin.saml2.keystore.alias}). */
-    public final static String KEYSTORE_ALIAS = "onelogin.saml2.keystore.alias";
+    public static final String KEYSTORE_ALIAS = "onelogin.saml2.keystore.alias";
     /** Property key for the KeyStore key password ({@code onelogin.saml2.keystore.key.password}). */
-    public final static String KEYSTORE_KEY_PASSWORD = "onelogin.saml2.keystore.key.password";
+    public static final String KEYSTORE_KEY_PASSWORD = "onelogin.saml2.keystore.key.password";
 
     // IDP
     /** Property key for the IdP entity ID ({@code onelogin.saml2.idp.entityid}). */
-    public final static String IDP_ENTITYID_PROPERTY_KEY = "onelogin.saml2.idp.entityid";
+    public static final String IDP_ENTITYID_PROPERTY_KEY = "onelogin.saml2.idp.entityid";
     /** Property key for the IdP Single Sign-On Service URL ({@code onelogin.saml2.idp.single_sign_on_service.url}). */
-    public final static String IDP_SINGLE_SIGN_ON_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.idp.single_sign_on_service.url";
+    public static final String IDP_SINGLE_SIGN_ON_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.idp.single_sign_on_service.url";
     /** Property key for the IdP Single Sign-On Service binding ({@code onelogin.saml2.idp.single_sign_on_service.binding}). */
-    public final static String IDP_SINGLE_SIGN_ON_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.idp.single_sign_on_service.binding";
+    public static final String IDP_SINGLE_SIGN_ON_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.idp.single_sign_on_service.binding";
     /** Property key for the IdP Single Logout Service URL ({@code onelogin.saml2.idp.single_logout_service.url}). */
-    public final static String IDP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.idp.single_logout_service.url";
+    public static final String IDP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY = "onelogin.saml2.idp.single_logout_service.url";
     /** Property key for the IdP Single Logout Service response URL ({@code onelogin.saml2.idp.single_logout_service.response.url}). */
-    public final static String IDP_SINGLE_LOGOUT_SERVICE_RESPONSE_URL_PROPERTY_KEY =
+    public static final String IDP_SINGLE_LOGOUT_SERVICE_RESPONSE_URL_PROPERTY_KEY =
             "onelogin.saml2.idp.single_logout_service.response.url";
     /** Property key for the IdP Single Logout Service binding ({@code onelogin.saml2.idp.single_logout_service.binding}). */
-    public final static String IDP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.idp.single_logout_service.binding";
+    public static final String IDP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY = "onelogin.saml2.idp.single_logout_service.binding";
 
     /** Property key for the IdP X.509 certificate ({@code onelogin.saml2.idp.x509cert}). */
-    public final static String IDP_X509CERT_PROPERTY_KEY = "onelogin.saml2.idp.x509cert";
+    public static final String IDP_X509CERT_PROPERTY_KEY = "onelogin.saml2.idp.x509cert";
     /** Property key prefix for multiple IdP X.509 certificates ({@code onelogin.saml2.idp.x509certMulti}). */
-    public final static String IDP_X509CERTMULTI_PROPERTY_KEY = "onelogin.saml2.idp.x509certMulti";
+    public static final String IDP_X509CERTMULTI_PROPERTY_KEY = "onelogin.saml2.idp.x509certMulti";
     /** Property key for the IdP certificate fingerprint ({@code onelogin.saml2.idp.certfingerprint}). */
-    public final static String CERTFINGERPRINT_PROPERTY_KEY = "onelogin.saml2.idp.certfingerprint";
+    public static final String CERTFINGERPRINT_PROPERTY_KEY = "onelogin.saml2.idp.certfingerprint";
     /** Property key for the IdP certificate fingerprint algorithm ({@code onelogin.saml2.idp.certfingerprint_algorithm}). */
-    public final static String CERTFINGERPRINT_ALGORITHM_PROPERTY_KEY = "onelogin.saml2.idp.certfingerprint_algorithm";
+    public static final String CERTFINGERPRINT_ALGORITHM_PROPERTY_KEY = "onelogin.saml2.idp.certfingerprint_algorithm";
 
     // Security
     /** Property key controlling whether the NameID is encrypted ({@code onelogin.saml2.security.nameid_encrypted}). */
-    public final static String SECURITY_NAMEID_ENCRYPTED = "onelogin.saml2.security.nameid_encrypted";
+    public static final String SECURITY_NAMEID_ENCRYPTED = "onelogin.saml2.security.nameid_encrypted";
     /** Property key controlling whether AuthnRequests are signed ({@code onelogin.saml2.security.authnrequest_signed}). */
-    public final static String SECURITY_AUTHREQUEST_SIGNED = "onelogin.saml2.security.authnrequest_signed";
+    public static final String SECURITY_AUTHREQUEST_SIGNED = "onelogin.saml2.security.authnrequest_signed";
     /** Property key controlling whether LogoutRequests are signed ({@code onelogin.saml2.security.logoutrequest_signed}). */
-    public final static String SECURITY_LOGOUTREQUEST_SIGNED = "onelogin.saml2.security.logoutrequest_signed";
+    public static final String SECURITY_LOGOUTREQUEST_SIGNED = "onelogin.saml2.security.logoutrequest_signed";
     /** Property key controlling whether LogoutResponses are signed ({@code onelogin.saml2.security.logoutresponse_signed}). */
-    public final static String SECURITY_LOGOUTRESPONSE_SIGNED = "onelogin.saml2.security.logoutresponse_signed";
+    public static final String SECURITY_LOGOUTRESPONSE_SIGNED = "onelogin.saml2.security.logoutresponse_signed";
     /** Property key controlling whether received messages must be signed ({@code onelogin.saml2.security.want_messages_signed}). */
-    public final static String SECURITY_WANT_MESSAGES_SIGNED = "onelogin.saml2.security.want_messages_signed";
+    public static final String SECURITY_WANT_MESSAGES_SIGNED = "onelogin.saml2.security.want_messages_signed";
     /** Property key controlling whether received assertions must be signed ({@code onelogin.saml2.security.want_assertions_signed}). */
-    public final static String SECURITY_WANT_ASSERTIONS_SIGNED = "onelogin.saml2.security.want_assertions_signed";
+    public static final String SECURITY_WANT_ASSERTIONS_SIGNED = "onelogin.saml2.security.want_assertions_signed";
     /** Property key controlling whether received assertions must be encrypted ({@code onelogin.saml2.security.want_assertions_encrypted}). */
-    public final static String SECURITY_WANT_ASSERTIONS_ENCRYPTED = "onelogin.saml2.security.want_assertions_encrypted";
+    public static final String SECURITY_WANT_ASSERTIONS_ENCRYPTED = "onelogin.saml2.security.want_assertions_encrypted";
     /** Property key controlling whether a NameID is required in responses ({@code onelogin.saml2.security.want_nameid}). */
-    public final static String SECURITY_WANT_NAMEID = "onelogin.saml2.security.want_nameid";
+    public static final String SECURITY_WANT_NAMEID = "onelogin.saml2.security.want_nameid";
     /** Property key controlling whether the received NameID must be encrypted ({@code onelogin.saml2.security.want_nameid_encrypted}). */
-    public final static String SECURITY_WANT_NAMEID_ENCRYPTED = "onelogin.saml2.security.want_nameid_encrypted";
+    public static final String SECURITY_WANT_NAMEID_ENCRYPTED = "onelogin.saml2.security.want_nameid_encrypted";
     /** Property key controlling whether the SP metadata is signed ({@code onelogin.saml2.security.sign_metadata}). */
-    public final static String SECURITY_SIGN_METADATA = "onelogin.saml2.security.sign_metadata";
+    public static final String SECURITY_SIGN_METADATA = "onelogin.saml2.security.sign_metadata";
     /** Property key for the requested authentication context(s) ({@code onelogin.saml2.security.requested_authncontext}). */
-    public final static String SECURITY_REQUESTED_AUTHNCONTEXT = "onelogin.saml2.security.requested_authncontext";
+    public static final String SECURITY_REQUESTED_AUTHNCONTEXT = "onelogin.saml2.security.requested_authncontext";
     /** Property key for the requested authentication context comparison ({@code onelogin.saml2.security.requested_authncontextcomparison}). */
-    public final static String SECURITY_REQUESTED_AUTHNCONTEXTCOMPARISON = "onelogin.saml2.security.requested_authncontextcomparison";
+    public static final String SECURITY_REQUESTED_AUTHNCONTEXTCOMPARISON = "onelogin.saml2.security.requested_authncontextcomparison";
     /** Property key controlling whether XML schema validation is performed ({@code onelogin.saml2.security.want_xml_validation}). */
-    public final static String SECURITY_WANT_XML_VALIDATION = "onelogin.saml2.security.want_xml_validation";
+    public static final String SECURITY_WANT_XML_VALIDATION = "onelogin.saml2.security.want_xml_validation";
     /** Property key for the signature algorithm used when signing ({@code onelogin.saml2.security.signature_algorithm}). */
-    public final static String SECURITY_SIGNATURE_ALGORITHM = "onelogin.saml2.security.signature_algorithm";
+    public static final String SECURITY_SIGNATURE_ALGORITHM = "onelogin.saml2.security.signature_algorithm";
     /** Property key for the digest algorithm used when signing ({@code onelogin.saml2.security.digest_algorithm}). */
-    public final static String SECURITY_DIGEST_ALGORITHM = "onelogin.saml2.security.digest_algorithm";
+    public static final String SECURITY_DIGEST_ALGORITHM = "onelogin.saml2.security.digest_algorithm";
     /** Property key for the key transport algorithm used to encrypt the NameID ({@code onelogin.saml2.security.nameid_encryption_algorithm}). */
-    public final static String SECURITY_NAMEID_ENCRYPTION_ALGORITHM = "onelogin.saml2.security.nameid_encryption_algorithm";
+    public static final String SECURITY_NAMEID_ENCRYPTION_ALGORITHM = "onelogin.saml2.security.nameid_encryption_algorithm";
     /** Property key for the comma-separated allow-list of key transport algorithms accepted on decrypt ({@code onelogin.saml2.security.allowed_key_transport_algorithms}). */
-    public final static String SECURITY_ALLOWED_KEY_TRANSPORT_ALGORITHMS = "onelogin.saml2.security.allowed_key_transport_algorithms";
+    public static final String SECURITY_ALLOWED_KEY_TRANSPORT_ALGORITHMS = "onelogin.saml2.security.allowed_key_transport_algorithms";
     /** Property key controlling whether unsolicited responses with an InResponseTo attribute are rejected ({@code onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto}). */
-    public final static String SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO =
+    public static final String SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO =
             "onelogin.saml2.security.reject_unsolicited_responses_with_inresponseto";
     /** Property key controlling whether duplicated attribute names are allowed ({@code onelogin.saml2.security.allow_duplicated_attribute_name}). */
-    public final static String SECURITY_ALLOW_REPEAT_ATTRIBUTE_NAME_PROPERTY_KEY =
+    public static final String SECURITY_ALLOW_REPEAT_ATTRIBUTE_NAME_PROPERTY_KEY =
             "onelogin.saml2.security.allow_duplicated_attribute_name";
     /** Property key controlling whether deprecated cryptographic algorithms are rejected ({@code onelogin.saml2.security.reject_deprecated_alg}). */
-    public final static String SECURITY_REJECT_DEPRECATED_ALGORITHM = "onelogin.saml2.security.reject_deprecated_alg";
+    public static final String SECURITY_REJECT_DEPRECATED_ALGORITHM = "onelogin.saml2.security.reject_deprecated_alg";
 
     // Compress
     /** Property key controlling whether outgoing requests are compressed ({@code onelogin.saml2.compress.request}). */
-    public final static String COMPRESS_REQUEST = "onelogin.saml2.compress.request";
+    public static final String COMPRESS_REQUEST = "onelogin.saml2.compress.request";
     /** Property key controlling whether outgoing responses are compressed ({@code onelogin.saml2.compress.response}). */
-    public final static String COMPRESS_RESPONSE = "onelogin.saml2.compress.response";
+    public static final String COMPRESS_RESPONSE = "onelogin.saml2.compress.response";
 
     // Parsing
     /** Property key controlling whether NameID values are trimmed during parsing ({@code onelogin.saml2.parsing.trim_name_ids}). */
-    public final static String PARSING_TRIM_NAME_IDS = "onelogin.saml2.parsing.trim_name_ids";
+    public static final String PARSING_TRIM_NAME_IDS = "onelogin.saml2.parsing.trim_name_ids";
     /** Property key controlling whether attribute values are trimmed during parsing ({@code onelogin.saml2.parsing.trim_attribute_values}). */
-    public final static String PARSING_TRIM_ATTRIBUTE_VALUES = "onelogin.saml2.parsing.trim_attribute_values";
+    public static final String PARSING_TRIM_ATTRIBUTE_VALUES = "onelogin.saml2.parsing.trim_attribute_values";
 
     // Misc
     /**
@@ -203,39 +203,39 @@ public class SettingsBuilder {
      * @deprecated use the indexed {@code onelogin.saml2.sp.contact} properties instead
      */
     @Deprecated
-    public final static String CONTACT_TECHNICAL_GIVEN_NAME = "onelogin.saml2.contacts.technical.given_name";
+    public static final String CONTACT_TECHNICAL_GIVEN_NAME = "onelogin.saml2.contacts.technical.given_name";
     /**
      * Property key for the legacy technical contact e-mail address ({@code onelogin.saml2.contacts.technical.email_address}).
      *
      * @deprecated use the indexed {@code onelogin.saml2.sp.contact} properties instead
      */
     @Deprecated
-    public final static String CONTACT_TECHNICAL_EMAIL_ADDRESS = "onelogin.saml2.contacts.technical.email_address";
+    public static final String CONTACT_TECHNICAL_EMAIL_ADDRESS = "onelogin.saml2.contacts.technical.email_address";
     /**
      * Property key for the legacy support contact given name ({@code onelogin.saml2.contacts.support.given_name}).
      *
      * @deprecated use the indexed {@code onelogin.saml2.sp.contact} properties instead
      */
     @Deprecated
-    public final static String CONTACT_SUPPORT_GIVEN_NAME = "onelogin.saml2.contacts.support.given_name";
+    public static final String CONTACT_SUPPORT_GIVEN_NAME = "onelogin.saml2.contacts.support.given_name";
     /**
      * Property key for the legacy support contact e-mail address ({@code onelogin.saml2.contacts.support.email_address}).
      *
      * @deprecated use the indexed {@code onelogin.saml2.sp.contact} properties instead
      */
     @Deprecated
-    public final static String CONTACT_SUPPORT_EMAIL_ADDRESS = "onelogin.saml2.contacts.support.email_address";
+    public static final String CONTACT_SUPPORT_EMAIL_ADDRESS = "onelogin.saml2.contacts.support.email_address";
 
     /** Property key for the organization name ({@code onelogin.saml2.organization.name}). */
-    public final static String ORGANIZATION_NAME = "onelogin.saml2.organization.name";
+    public static final String ORGANIZATION_NAME = "onelogin.saml2.organization.name";
     /** Property key for the organization display name ({@code onelogin.saml2.organization.displayname}). */
-    public final static String ORGANIZATION_DISPLAYNAME = "onelogin.saml2.organization.displayname";
+    public static final String ORGANIZATION_DISPLAYNAME = "onelogin.saml2.organization.displayname";
     /** Property key for the organization URL ({@code onelogin.saml2.organization.url}). */
-    public final static String ORGANIZATION_URL = "onelogin.saml2.organization.url";
+    public static final String ORGANIZATION_URL = "onelogin.saml2.organization.url";
     /** Property key for the organization language ({@code onelogin.saml2.organization.lang}). */
-    public final static String ORGANIZATION_LANG = "onelogin.saml2.organization.lang";
+    public static final String ORGANIZATION_LANG = "onelogin.saml2.organization.lang";
     /** Property key for the prefix used to generate unique IDs ({@code onelogin.saml2.unique_id_prefix}). */
-    public final static String UNIQUE_ID_PREFIX_PROPERTY_KEY = "onelogin.saml2.unique_id_prefix";
+    public static final String UNIQUE_ID_PREFIX_PROPERTY_KEY = "onelogin.saml2.unique_id_prefix";
 
     /**
      * Load settings from the file
@@ -350,7 +350,7 @@ public class SettingsBuilder {
      */
     public Saml2Settings build(final Saml2Settings saml2Setting) {
 
-        this.saml2Setting = saml2Setting;
+        this.saml2Settings = saml2Setting;
 
         final Boolean strict = loadBooleanProperty(STRICT_PROPERTY_KEY);
         if (strict != null) {
@@ -378,7 +378,7 @@ public class SettingsBuilder {
             saml2Setting.setOrganization(org);
         }
 
-        final String uniqueIdPrefix = loadUniqueIDPrefix();
+        final String uniqueIdPrefix = loadUniqueIdPrefix();
         if (StringUtils.isNotEmpty(uniqueIdPrefix)) {
             saml2Setting.setUniqueIDPrefix(uniqueIdPrefix);
         } else if (saml2Setting.getUniqueIDPrefix() == null) {
@@ -398,54 +398,54 @@ public class SettingsBuilder {
      * Loads the IdP settings from the properties file
      */
     private void loadIdpSetting() {
-        final String idpEntityID = loadStringProperty(IDP_ENTITYID_PROPERTY_KEY);
-        if (idpEntityID != null) {
-            saml2Setting.setIdpEntityId(idpEntityID);
+        final String idpEntityId = loadStringProperty(IDP_ENTITYID_PROPERTY_KEY);
+        if (idpEntityId != null) {
+            saml2Settings.setIdpEntityId(idpEntityId);
         }
 
         final URL idpSingleSignOnServiceUrl = loadURLProperty(IDP_SINGLE_SIGN_ON_SERVICE_URL_PROPERTY_KEY);
         if (idpSingleSignOnServiceUrl != null) {
-            saml2Setting.setIdpSingleSignOnServiceUrl(idpSingleSignOnServiceUrl);
+            saml2Settings.setIdpSingleSignOnServiceUrl(idpSingleSignOnServiceUrl);
         }
 
         final String idpSingleSignOnServiceBinding = loadStringProperty(IDP_SINGLE_SIGN_ON_SERVICE_BINDING_PROPERTY_KEY);
         if (idpSingleSignOnServiceBinding != null) {
-            saml2Setting.setIdpSingleSignOnServiceBinding(idpSingleSignOnServiceBinding);
+            saml2Settings.setIdpSingleSignOnServiceBinding(idpSingleSignOnServiceBinding);
         }
 
         final URL idpSingleLogoutServiceUrl = loadURLProperty(IDP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY);
         if (idpSingleLogoutServiceUrl != null) {
-            saml2Setting.setIdpSingleLogoutServiceUrl(idpSingleLogoutServiceUrl);
+            saml2Settings.setIdpSingleLogoutServiceUrl(idpSingleLogoutServiceUrl);
         }
 
         final URL idpSingleLogoutServiceResponseUrl = loadURLProperty(IDP_SINGLE_LOGOUT_SERVICE_RESPONSE_URL_PROPERTY_KEY);
         if (idpSingleLogoutServiceResponseUrl != null) {
-            saml2Setting.setIdpSingleLogoutServiceResponseUrl(idpSingleLogoutServiceResponseUrl);
+            saml2Settings.setIdpSingleLogoutServiceResponseUrl(idpSingleLogoutServiceResponseUrl);
         }
 
         final String idpSingleLogoutServiceBinding = loadStringProperty(IDP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY);
         if (idpSingleLogoutServiceBinding != null) {
-            saml2Setting.setIdpSingleLogoutServiceBinding(idpSingleLogoutServiceBinding);
+            saml2Settings.setIdpSingleLogoutServiceBinding(idpSingleLogoutServiceBinding);
         }
 
-        final List<X509Certificate> idpX509certMulti = loadCertificateListFromProp(IDP_X509CERTMULTI_PROPERTY_KEY);
-        if (idpX509certMulti != null) {
-            saml2Setting.setIdpx509certMulti(idpX509certMulti);
+        final List<X509Certificate> idpX509CertMulti = loadCertificateListFromProp(IDP_X509CERTMULTI_PROPERTY_KEY);
+        if (idpX509CertMulti != null) {
+            saml2Settings.setIdpx509certMulti(idpX509CertMulti);
         }
 
-        final X509Certificate idpX509cert = loadCertificateFromProp(IDP_X509CERT_PROPERTY_KEY);
-        if (idpX509cert != null) {
-            saml2Setting.setIdpx509cert(idpX509cert);
+        final X509Certificate idpX509Cert = loadCertificateFromProp(IDP_X509CERT_PROPERTY_KEY);
+        if (idpX509Cert != null) {
+            saml2Settings.setIdpx509cert(idpX509Cert);
         }
 
         final String idpCertFingerprint = loadStringProperty(CERTFINGERPRINT_PROPERTY_KEY);
         if (idpCertFingerprint != null) {
-            saml2Setting.setIdpCertFingerprint(idpCertFingerprint);
+            saml2Settings.setIdpCertFingerprint(idpCertFingerprint);
         }
 
         final String idpCertFingerprintAlgorithm = loadStringProperty(CERTFINGERPRINT_ALGORITHM_PROPERTY_KEY);
-        if (idpCertFingerprintAlgorithm != null && !idpCertFingerprintAlgorithm.isEmpty()) {
-            saml2Setting.setIdpCertFingerprintAlgorithm(idpCertFingerprintAlgorithm);
+        if (StringUtils.isNotEmpty(idpCertFingerprintAlgorithm)) {
+            saml2Settings.setIdpCertFingerprintAlgorithm(idpCertFingerprintAlgorithm);
         }
     }
 
@@ -455,82 +455,82 @@ public class SettingsBuilder {
     private void loadSecuritySetting() {
         final Boolean nameIdEncrypted = loadBooleanProperty(SECURITY_NAMEID_ENCRYPTED);
         if (nameIdEncrypted != null) {
-            saml2Setting.setNameIdEncrypted(nameIdEncrypted);
+            saml2Settings.setNameIdEncrypted(nameIdEncrypted);
         }
 
         final Boolean authnRequestsSigned = loadBooleanProperty(SECURITY_AUTHREQUEST_SIGNED);
         if (authnRequestsSigned != null) {
-            saml2Setting.setAuthnRequestsSigned(authnRequestsSigned);
+            saml2Settings.setAuthnRequestsSigned(authnRequestsSigned);
         }
 
         final Boolean logoutRequestSigned = loadBooleanProperty(SECURITY_LOGOUTREQUEST_SIGNED);
         if (logoutRequestSigned != null) {
-            saml2Setting.setLogoutRequestSigned(logoutRequestSigned);
+            saml2Settings.setLogoutRequestSigned(logoutRequestSigned);
         }
 
         final Boolean logoutResponseSigned = loadBooleanProperty(SECURITY_LOGOUTRESPONSE_SIGNED);
         if (logoutResponseSigned != null) {
-            saml2Setting.setLogoutResponseSigned(logoutResponseSigned);
+            saml2Settings.setLogoutResponseSigned(logoutResponseSigned);
         }
 
         final Boolean wantMessagesSigned = loadBooleanProperty(SECURITY_WANT_MESSAGES_SIGNED);
         if (wantMessagesSigned != null) {
-            saml2Setting.setWantMessagesSigned(wantMessagesSigned);
+            saml2Settings.setWantMessagesSigned(wantMessagesSigned);
         }
 
         final Boolean wantAssertionsSigned = loadBooleanProperty(SECURITY_WANT_ASSERTIONS_SIGNED);
         if (wantAssertionsSigned != null) {
-            saml2Setting.setWantAssertionsSigned(wantAssertionsSigned);
+            saml2Settings.setWantAssertionsSigned(wantAssertionsSigned);
         }
 
         final Boolean wantAssertionsEncrypted = loadBooleanProperty(SECURITY_WANT_ASSERTIONS_ENCRYPTED);
         if (wantAssertionsEncrypted != null) {
-            saml2Setting.setWantAssertionsEncrypted(wantAssertionsEncrypted);
+            saml2Settings.setWantAssertionsEncrypted(wantAssertionsEncrypted);
         }
 
         final Boolean wantNameId = loadBooleanProperty(SECURITY_WANT_NAMEID);
         if (wantNameId != null) {
-            saml2Setting.setWantNameId(wantNameId);
+            saml2Settings.setWantNameId(wantNameId);
         }
 
         final Boolean wantNameIdEncrypted = loadBooleanProperty(SECURITY_WANT_NAMEID_ENCRYPTED);
         if (wantNameIdEncrypted != null) {
-            saml2Setting.setWantNameIdEncrypted(wantNameIdEncrypted);
+            saml2Settings.setWantNameIdEncrypted(wantNameIdEncrypted);
         }
 
-        final Boolean wantXMLValidation = loadBooleanProperty(SECURITY_WANT_XML_VALIDATION);
-        if (wantXMLValidation != null) {
-            saml2Setting.setWantXMLValidation(wantXMLValidation);
+        final Boolean wantXmlValidation = loadBooleanProperty(SECURITY_WANT_XML_VALIDATION);
+        if (wantXmlValidation != null) {
+            saml2Settings.setWantXMLValidation(wantXmlValidation);
         }
 
         final Boolean signMetadata = loadBooleanProperty(SECURITY_SIGN_METADATA);
         if (signMetadata != null) {
-            saml2Setting.setSignMetadata(signMetadata);
+            saml2Settings.setSignMetadata(signMetadata);
         }
 
         final List<String> requestedAuthnContext = loadListProperty(SECURITY_REQUESTED_AUTHNCONTEXT);
         if (requestedAuthnContext != null) {
-            saml2Setting.setRequestedAuthnContext(requestedAuthnContext);
+            saml2Settings.setRequestedAuthnContext(requestedAuthnContext);
         }
 
         final String requestedAuthnContextComparison = loadStringProperty(SECURITY_REQUESTED_AUTHNCONTEXTCOMPARISON);
-        if (requestedAuthnContextComparison != null && !requestedAuthnContextComparison.isEmpty()) {
-            saml2Setting.setRequestedAuthnContextComparison(requestedAuthnContextComparison);
+        if (StringUtils.isNotEmpty(requestedAuthnContextComparison)) {
+            saml2Settings.setRequestedAuthnContextComparison(requestedAuthnContextComparison);
         }
 
         final String signatureAlgorithm = loadStringProperty(SECURITY_SIGNATURE_ALGORITHM);
-        if (signatureAlgorithm != null && !signatureAlgorithm.isEmpty()) {
-            saml2Setting.setSignatureAlgorithm(signatureAlgorithm);
+        if (StringUtils.isNotEmpty(signatureAlgorithm)) {
+            saml2Settings.setSignatureAlgorithm(signatureAlgorithm);
         }
 
         final String digestAlgorithm = loadStringProperty(SECURITY_DIGEST_ALGORITHM);
-        if (digestAlgorithm != null && !digestAlgorithm.isEmpty()) {
-            saml2Setting.setDigestAlgorithm(digestAlgorithm);
+        if (StringUtils.isNotEmpty(digestAlgorithm)) {
+            saml2Settings.setDigestAlgorithm(digestAlgorithm);
         }
 
         final String nameIdEncryptionAlgorithm = loadStringProperty(SECURITY_NAMEID_ENCRYPTION_ALGORITHM);
-        if (nameIdEncryptionAlgorithm != null && !nameIdEncryptionAlgorithm.isEmpty()) {
-            saml2Setting.setNameIdEncryptionAlgorithm(nameIdEncryptionAlgorithm);
+        if (StringUtils.isNotEmpty(nameIdEncryptionAlgorithm)) {
+            saml2Settings.setNameIdEncryptionAlgorithm(nameIdEncryptionAlgorithm);
         }
 
         final List<String> allowedKeyTransportAlgorithms = loadListProperty(SECURITY_ALLOWED_KEY_TRANSPORT_ALGORITHMS);
@@ -541,23 +541,23 @@ public class SettingsBuilder {
                     allowedKeyTransportAlgorithmsSet.add(allowedKeyTransportAlgorithm.trim());
                 }
             }
-            saml2Setting.setAllowedKeyTransportAlgorithms(allowedKeyTransportAlgorithmsSet);
+            saml2Settings.setAllowedKeyTransportAlgorithms(allowedKeyTransportAlgorithmsSet);
         }
 
         final Boolean rejectUnsolicitedResponsesWithInResponseTo =
                 loadBooleanProperty(SECURITY_REJECT_UNSOLICITED_RESPONSES_WITH_INRESPONSETO);
         if (rejectUnsolicitedResponsesWithInResponseTo != null) {
-            saml2Setting.setRejectUnsolicitedResponsesWithInResponseTo(rejectUnsolicitedResponsesWithInResponseTo);
+            saml2Settings.setRejectUnsolicitedResponsesWithInResponseTo(rejectUnsolicitedResponsesWithInResponseTo);
         }
 
         final Boolean allowRepeatAttributeName = loadBooleanProperty(SECURITY_ALLOW_REPEAT_ATTRIBUTE_NAME_PROPERTY_KEY);
         if (allowRepeatAttributeName != null) {
-            saml2Setting.setAllowRepeatAttributeName(allowRepeatAttributeName);
+            saml2Settings.setAllowRepeatAttributeName(allowRepeatAttributeName);
         }
 
         final Boolean rejectDeprecatedAlg = loadBooleanProperty(SECURITY_REJECT_DEPRECATED_ALGORITHM);
         if (rejectDeprecatedAlg != null) {
-            saml2Setting.setRejectDeprecatedAlg(rejectDeprecatedAlg);
+            saml2Settings.setRejectDeprecatedAlg(rejectDeprecatedAlg);
         }
     }
 
@@ -567,12 +567,12 @@ public class SettingsBuilder {
     private void loadCompressSetting() {
         final Boolean compressRequest = loadBooleanProperty(COMPRESS_REQUEST);
         if (compressRequest != null) {
-            saml2Setting.setCompressRequest(compressRequest);
+            saml2Settings.setCompressRequest(compressRequest);
         }
 
         final Boolean compressResponse = loadBooleanProperty(COMPRESS_RESPONSE);
         if (compressResponse != null) {
-            saml2Setting.setCompressResponse(compressResponse);
+            saml2Settings.setCompressResponse(compressResponse);
         }
     }
 
@@ -582,12 +582,12 @@ public class SettingsBuilder {
     private void loadParsingSetting() {
         final Boolean trimNameIds = loadBooleanProperty(PARSING_TRIM_NAME_IDS);
         if (trimNameIds != null) {
-            saml2Setting.setTrimNameIds(trimNameIds);
+            saml2Settings.setTrimNameIds(trimNameIds);
         }
 
         final Boolean trimAttributeValues = loadBooleanProperty(PARSING_TRIM_ATTRIBUTE_VALUES);
         if (trimAttributeValues != null) {
-            saml2Setting.setTrimAttributeValues(trimAttributeValues);
+            saml2Settings.setTrimAttributeValues(trimAttributeValues);
         }
     }
 
@@ -622,12 +622,12 @@ public class SettingsBuilder {
         // then build each contact
         // multiple indexed services specified
         final List<Contact> contacts =
-                contactProps.entrySet().stream().map(entry -> loadContact(entry.getValue(), entry.getKey())).collect(Collectors.toList());
+                contactProps.entrySet().stream().map(entry -> loadContact(entry.getValue())).collect(Collectors.toList());
         // append legacy contacts if present
         final String technicalGn = loadStringProperty(CONTACT_TECHNICAL_GIVEN_NAME);
         final String technicalEmailAddress = loadStringProperty(CONTACT_TECHNICAL_EMAIL_ADDRESS);
 
-        if ((technicalGn != null && !technicalGn.isEmpty()) || (technicalEmailAddress != null && !technicalEmailAddress.isEmpty())) {
+        if (StringUtils.isNotEmpty(technicalGn) || StringUtils.isNotEmpty(technicalEmailAddress)) {
             final Contact technical = new Contact(Constants.CONTACT_TYPE_TECHNICAL, technicalGn, technicalEmailAddress);
             contacts.add(technical);
         }
@@ -635,7 +635,7 @@ public class SettingsBuilder {
         final String supportGn = loadStringProperty(CONTACT_SUPPORT_GIVEN_NAME);
         final String supportEmailAddress = loadStringProperty(CONTACT_SUPPORT_EMAIL_ADDRESS);
 
-        if ((supportGn != null && !supportGn.isEmpty()) || (supportEmailAddress != null && !supportEmailAddress.isEmpty())) {
+        if (StringUtils.isNotEmpty(supportGn) || StringUtils.isNotEmpty(supportEmailAddress)) {
             final Contact support = new Contact(Constants.CONTACT_TYPE_SUPPORT, supportGn, supportEmailAddress);
             contacts.add(support);
         }
@@ -648,11 +648,9 @@ public class SettingsBuilder {
      *
      * @param contactProps
      *              a map containing the contact settings
-     * @param index
-     *              the contact index
      * @return the loaded contact
      */
-    private Contact loadContact(final Map<String, Object> contactProps, final int index) {
+    private Contact loadContact(final Map<String, Object> contactProps) {
         final String contactType = loadStringProperty(SP_CONTACT_CONTACT_TYPE_PROPERTY_KEY_SUFFIX, contactProps);
         final String company = loadStringProperty(SP_CONTACT_COMPANY_PROPERTY_KEY_SUFFIX, contactProps);
         final String givenName = loadStringProperty(SP_CONTACT_GIVEN_NAME_PROPERTY_KEY_SUFFIX, contactProps);
@@ -815,7 +813,7 @@ public class SettingsBuilder {
     /**
      * Loads the unique ID prefix. Uses default if property not set.
      */
-    private String loadUniqueIDPrefix() {
+    private String loadUniqueIdPrefix() {
         return loadStringProperty(UNIQUE_ID_PREFIX_PROPERTY_KEY);
     }
 
@@ -823,34 +821,34 @@ public class SettingsBuilder {
      * Loads the SP settings from the properties file
      */
     private void loadSpSetting() {
-        final String spEntityID = loadStringProperty(SP_ENTITYID_PROPERTY_KEY);
-        if (spEntityID != null) {
-            saml2Setting.setSpEntityId(spEntityID);
+        final String spEntityId = loadStringProperty(SP_ENTITYID_PROPERTY_KEY);
+        if (spEntityId != null) {
+            saml2Settings.setSpEntityId(spEntityId);
         }
 
         final URL assertionConsumerServiceUrl = loadURLProperty(SP_ASSERTION_CONSUMER_SERVICE_URL_PROPERTY_KEY);
         if (assertionConsumerServiceUrl != null) {
-            saml2Setting.setSpAssertionConsumerServiceUrl(assertionConsumerServiceUrl);
+            saml2Settings.setSpAssertionConsumerServiceUrl(assertionConsumerServiceUrl);
         }
 
         final String spAssertionConsumerServiceBinding = loadStringProperty(SP_ASSERTION_CONSUMER_SERVICE_BINDING_PROPERTY_KEY);
         if (spAssertionConsumerServiceBinding != null) {
-            saml2Setting.setSpAssertionConsumerServiceBinding(spAssertionConsumerServiceBinding);
+            saml2Settings.setSpAssertionConsumerServiceBinding(spAssertionConsumerServiceBinding);
         }
 
         final URL spSingleLogoutServiceUrl = loadURLProperty(SP_SINGLE_LOGOUT_SERVICE_URL_PROPERTY_KEY);
         if (spSingleLogoutServiceUrl != null) {
-            saml2Setting.setSpSingleLogoutServiceUrl(spSingleLogoutServiceUrl);
+            saml2Settings.setSpSingleLogoutServiceUrl(spSingleLogoutServiceUrl);
         }
 
         final String spSingleLogoutServiceBinding = loadStringProperty(SP_SINGLE_LOGOUT_SERVICE_BINDING_PROPERTY_KEY);
         if (spSingleLogoutServiceBinding != null) {
-            saml2Setting.setSpSingleLogoutServiceBinding(spSingleLogoutServiceBinding);
+            saml2Settings.setSpSingleLogoutServiceBinding(spSingleLogoutServiceBinding);
         }
 
-        final String spNameIDFormat = loadStringProperty(SP_NAMEIDFORMAT_PROPERTY_KEY);
-        if (spNameIDFormat != null && !spNameIDFormat.isEmpty()) {
-            saml2Setting.setSpNameIDFormat(spNameIDFormat);
+        final String spNameIdFormat = loadStringProperty(SP_NAMEIDFORMAT_PROPERTY_KEY);
+        if (StringUtils.isNotEmpty(spNameIdFormat)) {
+            saml2Settings.setSpNameIDFormat(spNameIdFormat);
         }
 
         final boolean keyStoreEnabled = this.samlData.get(KEYSTORE_KEY) != null && this.samlData.get(KEYSTORE_ALIAS) != null
@@ -872,15 +870,15 @@ public class SettingsBuilder {
         }
 
         if (spX509cert != null) {
-            saml2Setting.setSpX509cert(spX509cert);
+            saml2Settings.setSpX509cert(spX509cert);
         }
         if (spPrivateKey != null) {
-            saml2Setting.setSpPrivateKey(spPrivateKey);
+            saml2Settings.setSpPrivateKey(spPrivateKey);
         }
 
         final X509Certificate spX509certNew = loadCertificateFromProp(SP_X509CERTNEW_PROPERTY_KEY);
         if (spX509certNew != null) {
-            saml2Setting.setSpX509certNew(spX509certNew);
+            saml2Settings.setSpX509certNew(spX509certNew);
         }
     }
 
@@ -937,6 +935,7 @@ public class SettingsBuilder {
      *
      * @return the value
      */
+    @SuppressWarnings("unchecked")
     private List<String> loadListProperty(final String propertyKey) {
         final Object propValue = samlData.get(propertyKey);
         if (isString(propValue)) {
@@ -1081,10 +1080,8 @@ public class SettingsBuilder {
     private List<X509Certificate> loadCertificateListFromProp(final String propertyKey) {
         final List<X509Certificate> list = new ArrayList<>();
 
-        int i = 0;
-        while (true) {
+        for (int i = 0;; i++) {
             final Object propValue = samlData.get(propertyKey + "." + i);
-            i++;
 
             if (propValue == null) {
                 break;
@@ -1095,39 +1092,6 @@ public class SettingsBuilder {
 
         return list;
     }
-
-    /**
-     * Loads a property of the type X509Certificate from file
-     *
-     * @param filename the file name of the file that contains the X509Certificate
-     *
-     * @return the X509Certificate object
-     */
-    /*
-    protected X509Certificate loadCertificateFromFile(String filename) {
-    	String certString = null;
-    	try {
-    		certString = Util.getFileAsString(filename.trim());
-    	} catch (URISyntaxException e) {
-    		LOGGER.error("SAMLSevereException loading certificate from file.", e);
-    		return null;
-    	}
-    	catch (IOException e) {
-    		LOGGER.error("SAMLSevereException loading certificate from file.", e);
-    		return null;
-    	}
-    
-    	try {
-    		return Util.loadCert(certString);
-    	} catch (CertificateException e) {
-    		LOGGER.error("SAMLSevereException loading certificate from file.", e);
-    		return null;
-    	} catch (UnsupportedEncodingException e) {
-    		LOGGER.error("the certificate is not in correct format.", e);
-    		return null;
-    	}
-    }
-    */
 
     /**
      * Loads a property of the type PrivateKey from the Properties object

--- a/core/src/main/java/org/codelibs/saml2/core/util/Util.java
+++ b/core/src/main/java/org/codelibs/saml2/core/util/Util.java
@@ -8,11 +8,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -130,6 +128,9 @@ public final class Util {
 
     private static final Set<String> DEPRECATED_ALGOS = new HashSet<>(Arrays.asList(Constants.RSA_SHA1, Constants.DSA_SHA1));
 
+    private static final Set<String> WHITELISTED_ALGORITHMS =
+            Set.of(Constants.DSA_SHA1, Constants.RSA_SHA1, Constants.RSA_SHA256, Constants.RSA_SHA384, Constants.RSA_SHA512);
+
     static {
         System.setProperty("org.apache.xml.security.ignoreLineBreaks", "true");
         org.apache.xml.security.Init.init();
@@ -184,7 +185,7 @@ public final class Util {
             }
             LOGGER.warn("Detected use of ENTITY in XML, disabled to prevent XXE/XEE attacks");
         } catch (final Exception e) {
-            LOGGER.warn("Load XML error: " + e.getMessage(), e);
+            LOGGER.warn("Load XML error: {}", e.getMessage(), e);
         }
 
         return null;
@@ -241,13 +242,8 @@ public final class Util {
         });
 
         try {
-            NodeList nodeList;
-            if (context == null) {
-                nodeList = (NodeList) xpath.evaluate(query, dom, XPathConstants.NODESET);
-            } else {
-                nodeList = (NodeList) xpath.evaluate(query, context, XPathConstants.NODESET);
-            }
-            return nodeList;
+            final Node contextNode = context == null ? dom : context;
+            return (NodeList) xpath.evaluate(query, contextNode, XPathConstants.NODESET);
         } catch (XPathExpressionException e) {
             throw new XMLParsingException("Failed to evaluate " + query, e);
         }
@@ -295,15 +291,15 @@ public final class Util {
                 validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             }
 
-            final XMLErrorAccumulatorHandler errorAcumulator = new XMLErrorAccumulatorHandler();
-            validator.setErrorHandler(errorAcumulator);
+            final XMLErrorAccumulatorHandler errorAccumulator = new XMLErrorAccumulatorHandler();
+            validator.setErrorHandler(errorAccumulator);
 
             final Source xmlSource = new DOMSource(xmlDocument);
             validator.validate(xmlSource);
 
-            final boolean isValid = !errorAcumulator.hasError();
+            final boolean isValid = !errorAccumulator.hasError();
             if (!isValid) {
-                LOGGER.warn("Errors found when validating SAML response with schema: {}", errorAcumulator.getErrorXML());
+                LOGGER.warn("Errors found when validating SAML response with schema: {}", errorAccumulator.getErrorXML());
             }
             return isValid;
         } catch (final Exception e) {
@@ -336,36 +332,36 @@ public final class Util {
      * @return the Document object
      */
     public static Document parseXML(final InputSource inputSource) {
-        final DocumentBuilderFactory docfactory = DocumentBuilderFactory.newInstance();
-        docfactory.setNamespaceAware(true);
+        final DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        docFactory.setNamespaceAware(true);
 
         // do not expand entity reference nodes
-        docfactory.setExpandEntityReferences(false);
+        docFactory.setExpandEntityReferences(false);
 
-        docfactory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaLanguage", XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        docFactory.setAttribute("http://java.sun.com/xml/jaxp/properties/schemaLanguage", XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
         // Add various options explicitly to prevent XXE attacks.
         // (adding try/catch around every setAttribute just in case a specific parser does not support it.
         // do not include external general entities
-        setDocumentBuilderFactoryAttribute(docfactory, "http://xml.org/sax/features/external-general-entities", Boolean.FALSE);
+        setDocumentBuilderFactoryAttribute(docFactory, "http://xml.org/sax/features/external-general-entities", Boolean.FALSE);
         // do not include external parameter entities or the external DTD subset
-        setDocumentBuilderFactoryAttribute(docfactory, "http://xml.org/sax/features/external-parameter-entities", Boolean.FALSE);
-        setDocumentBuilderFactoryAttribute(docfactory, "http://apache.org/xml/features/disallow-doctype-decl", Boolean.TRUE);
-        setDocumentBuilderFactoryAttribute(docfactory, "http://javax.xml.XMLConstants/feature/secure-processing", Boolean.TRUE);
+        setDocumentBuilderFactoryAttribute(docFactory, "http://xml.org/sax/features/external-parameter-entities", Boolean.FALSE);
+        setDocumentBuilderFactoryAttribute(docFactory, "http://apache.org/xml/features/disallow-doctype-decl", Boolean.TRUE);
+        setDocumentBuilderFactoryAttribute(docFactory, "http://javax.xml.XMLConstants/feature/secure-processing", Boolean.TRUE);
         // ignore the external DTD completely
-        setDocumentBuilderFactoryAttribute(docfactory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", Boolean.FALSE);
+        setDocumentBuilderFactoryAttribute(docFactory, "http://apache.org/xml/features/nonvalidating/load-external-dtd", Boolean.FALSE);
         // build the grammar but do not use the default attributes and attribute types information it contains
-        setDocumentBuilderFactoryAttribute(docfactory, "http://apache.org/xml/features/nonvalidating/load-dtd-grammar", Boolean.FALSE);
+        setDocumentBuilderFactoryAttribute(docFactory, "http://apache.org/xml/features/nonvalidating/load-dtd-grammar", Boolean.FALSE);
         try {
-            docfactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            docFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         } catch (final Exception e) {
             LOGGER.debug("Cannot set {} to {}", true, XMLConstants.FEATURE_SECURE_PROCESSING, e);
         }
 
         try {
-            final DocumentBuilder builder = docfactory.newDocumentBuilder();
-            final XMLErrorAccumulatorHandler errorAcumulator = new XMLErrorAccumulatorHandler();
-            builder.setErrorHandler(errorAcumulator);
+            final DocumentBuilder builder = docFactory.newDocumentBuilder();
+            final XMLErrorAccumulatorHandler errorAccumulator = new XMLErrorAccumulatorHandler();
+            builder.setErrorHandler(errorAccumulator);
             final Document doc = builder.parse(inputSource);
 
             // Loop through the doc and tag every element with an ID attribute
@@ -392,9 +388,9 @@ public final class Util {
         }
     }
 
-    private static void setDocumentBuilderFactoryAttribute(DocumentBuilderFactory docfactory, String name, Object value) {
+    private static void setDocumentBuilderFactoryAttribute(DocumentBuilderFactory docFactory, String name, Object value) {
         try {
-            docfactory.setAttribute(name, value);
+            docFactory.setAttribute(name, value);
         } catch (final Exception e) {
             LOGGER.debug("Cannot set {} to {}", value, name, e);
         }
@@ -650,15 +646,15 @@ public final class Util {
      * @return the formated PEM string
      */
     public static String convertToPem(final X509Certificate certificate) {
-        String pemCert = "";
+        String pemCert = StringUtils.EMPTY;
         try {
             final Base64 encoder = new Base64(64);
-            final String cert_begin = "-----BEGIN CERTIFICATE-----\n";
-            final String end_cert = "-----END CERTIFICATE-----";
+            final String certBegin = "-----BEGIN CERTIFICATE-----\n";
+            final String certEnd = "-----END CERTIFICATE-----";
 
             final byte[] derCert = certificate.getEncoded();
             final String pemCertPre = new String(encoder.encode(derCert));
-            pemCert = cert_begin + pemCertPre + end_cert;
+            pemCert = certBegin + pemCertPre + certEnd;
 
         } catch (final Exception e) {
             LOGGER.debug("Certificate encoding exception.", e);
@@ -684,7 +680,7 @@ public final class Util {
             final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             copyBytes(new BufferedInputStream(is), bytes);
 
-            return bytes.toString("utf-8");
+            return bytes.toString(StandardCharsets.UTF_8);
         } catch (final IOException e) {
             throw new IORuntimeException(e);
         }
@@ -715,17 +711,17 @@ public final class Util {
 
         // Inflater
         try {
-            final Inflater decompresser = new Inflater(true);
-            decompresser.setInput(decoded);
+            final Inflater decompressor = new Inflater(true);
+            decompressor.setInput(decoded);
             final byte[] result = new byte[1024];
             StringBuilder inflated = new StringBuilder();
             long limit = 0;
-            while (!decompresser.finished() && limit < 150) {
-                final int resultLength = decompresser.inflate(result);
+            while (!decompressor.finished() && limit < 150) {
+                final int resultLength = decompressor.inflate(result);
                 limit += 1;
-                inflated.append(new String(result, 0, resultLength, "UTF-8"));
+                inflated.append(new String(result, 0, resultLength, StandardCharsets.UTF_8));
             }
-            decompresser.end();
+            decompressor.end();
             return inflated.toString();
         } catch (final Exception e) {
             LOGGER.debug("Failed to decode {}", input, e);
@@ -746,7 +742,7 @@ public final class Util {
         final ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
         final Deflater deflater = new Deflater(Deflater.DEFLATED, true);
         try (final DeflaterOutputStream deflaterStream = new DeflaterOutputStream(bytesOut, deflater)) {
-            deflaterStream.write(input.getBytes(Charset.forName("UTF-8")));
+            deflaterStream.write(input.getBytes(StandardCharsets.UTF_8));
             deflaterStream.finish();
         } catch (final IOException e) {
             throw new IORuntimeException(e);
@@ -970,8 +966,6 @@ public final class Util {
                             if (validateSignNode(signature, cert, null, null, null)) {
                                 return true;
                             }
-                        } else {
-                            continue;
                         }
                     } else if (validateSignNode(signature, cert, fingerprint, extractedCert, extractedFingerprint)) {
                         return true;
@@ -1219,19 +1213,9 @@ public final class Util {
      * @return True if the sign is valid, false otherwise.
      */
     public static boolean isAlgorithmWhitelisted(final String alg) {
-        final Set<String> whiteListedAlgorithm = new HashSet<>();
-        whiteListedAlgorithm.add(Constants.DSA_SHA1);
-        whiteListedAlgorithm.add(Constants.RSA_SHA1);
-        whiteListedAlgorithm.add(Constants.RSA_SHA256);
-        whiteListedAlgorithm.add(Constants.RSA_SHA384);
-        whiteListedAlgorithm.add(Constants.RSA_SHA512);
-
-        boolean whitelisted = false;
-        if (whiteListedAlgorithm.contains(alg)) {
-            whitelisted = true;
-        }
-
-        return whitelisted;
+        // Preserve the original null contract: an immutable Set.of(...) throws on contains(null),
+        // whereas the previous HashSet returned false for a null algorithm.
+        return alg != null && WHITELISTED_ALGORITHMS.contains(alg);
     }
 
     /**
@@ -1409,10 +1393,11 @@ public final class Util {
                     ValidationException.KEYINFO_NOT_FOUND_IN_ENCRYPTED_DATA);
         }
 
-        final NodeList childs = keyInfoInEncData.item(0).getChildNodes();
-        for (int i = 0; i < childs.getLength(); i++) {
-            if (childs.item(i).getLocalName() != null && "RetrievalMethod".equals(childs.item(i).getLocalName())) {
-                final Element retrievalMethodElem = (Element) childs.item(i);
+        final NodeList children = keyInfoInEncData.item(0).getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node child = children.item(i);
+            if (child.getLocalName() != null && "RetrievalMethod".equals(child.getLocalName())) {
+                final Element retrievalMethodElem = (Element) child;
                 if (!"http://www.w3.org/2001/04/xmlenc#EncryptedKey".equals(retrievalMethodElem.getAttribute("Type"))) {
                     throw new ValidationException("Unsupported Retrieval Method found", ValidationException.UNSUPPORTED_RETRIEVAL_METHOD);
                 }
@@ -1423,7 +1408,7 @@ public final class Util {
                         ((Element) encryptedDataElement.getParentNode()).getElementsByTagNameNS(Constants.NS_XENC, "EncryptedKey");
                 for (int j = 0; j < encryptedKeyNodes.getLength(); j++) {
                     if (((Element) encryptedKeyNodes.item(j)).getAttribute("Id").equals(uri)) {
-                        keyInfoInEncData.item(0).replaceChild(encryptedKeyNodes.item(j), childs.item(i));
+                        keyInfoInEncData.item(0).replaceChild(encryptedKeyNodes.item(j), child);
                     }
                 }
             }
@@ -1704,7 +1689,7 @@ public final class Util {
                         break;
                     }
                 } catch (final Exception e) {
-                    LOGGER.warn("SAMLSevereException executing validateSign: " + e.getMessage(), e);
+                    LOGGER.warn("SAMLSevereException executing validateSign: {}", e.getMessage(), e);
                 }
             }
             return valid;
@@ -1735,8 +1720,8 @@ public final class Util {
         if (codeEntry.getLength() == 0) {
             throw new ValidationException("Missing Status Code on response", ValidationException.MISSING_STATUS_CODE);
         }
-        final String stausCode = codeEntry.item(0).getAttributes().getNamedItem("Value").getNodeValue();
-        final SamlResponseStatus status = new SamlResponseStatus(stausCode);
+        final String statusCode = codeEntry.item(0).getAttributes().getNamedItem("Value").getNodeValue();
+        final SamlResponseStatus status = new SamlResponseStatus(statusCode);
 
         final NodeList subStatusCodeEntry = Util.query(dom, statusXpath + "/samlp:StatusCode/samlp:StatusCode", statusEntry.item(0));
         if (subStatusCodeEntry.getLength() > 0) {
@@ -1923,7 +1908,7 @@ public final class Util {
      * @return A unique string
      */
     public static String generateUniqueID(String prefix) {
-        if (prefix == null || StringUtils.isEmpty(prefix)) {
+        if (StringUtils.isEmpty(prefix)) {
             prefix = Util.UNIQUE_ID_PREFIX;
         }
         return prefix + UUID.randomUUID();
@@ -2013,11 +1998,11 @@ public final class Util {
     public static long getExpireTime(final String cacheDuration, final String validUntil) {
         long expireTime = 0;
         try {
-            if (cacheDuration != null && !StringUtils.isEmpty(cacheDuration)) {
+            if (StringUtils.isNotEmpty(cacheDuration)) {
                 expireTime = parseDuration(cacheDuration);
             }
 
-            if (validUntil != null && !StringUtils.isEmpty(validUntil)) {
+            if (StringUtils.isNotEmpty(validUntil)) {
                 final Instant dt = Util.parseDateTime(validUntil);
                 final long validUntilTimeInt = dt.toEpochMilli() / 1000;
                 if (expireTime == 0 || expireTime > validUntilTimeInt) {
@@ -2025,7 +2010,7 @@ public final class Util {
                 }
             }
         } catch (final Exception e) {
-            LOGGER.error("SAMLSevereException executing getExpireTime: " + e.getMessage(), e);
+            LOGGER.error("SAMLSevereException executing getExpireTime: {}", e.getMessage(), e);
         }
         return expireTime;
     }
@@ -2043,7 +2028,7 @@ public final class Util {
     public static long getExpireTime(final String cacheDuration, final long validUntil) {
         long expireTime = 0;
         try {
-            if (cacheDuration != null && !StringUtils.isEmpty(cacheDuration)) {
+            if (StringUtils.isNotEmpty(cacheDuration)) {
                 expireTime = parseDuration(cacheDuration);
             }
 
@@ -2051,7 +2036,7 @@ public final class Util {
                 expireTime = validUntil;
             }
         } catch (final Exception e) {
-            LOGGER.error("SAMLSevereException executing getExpireTime: " + e.getMessage(), e);
+            LOGGER.error("SAMLSevereException executing getExpireTime: {}", e.getMessage(), e);
         }
         return expireTime;
     }
@@ -2093,19 +2078,11 @@ public final class Util {
     }
 
     private static String toStringUtf8(final byte[] bytes) {
-        try {
-            return new String(bytes, "UTF-8");
-        } catch (final UnsupportedEncodingException e) {
-            throw new IllegalStateException(e);
-        }
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     private static byte[] toBytesUtf8(final String str) {
-        try {
-            return str.getBytes("UTF-8");
-        } catch (final UnsupportedEncodingException e) {
-            throw new IllegalStateException(e);
-        }
+        return str.getBytes(StandardCharsets.UTF_8);
     }
 
     private static Clock clock = Clock.systemUTC();

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/acs.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/acs.jsp
@@ -1,6 +1,5 @@
-<%@page import="org.codelibs.saml2.core.core.toolkit.Auth"%>
-<%@page import="org.codelibs.saml2.core.core.toolkit.servlet.ServletUtils"%>
-<%@page import="java.util.Collection"%>
+<%@page import="org.codelibs.saml2.Auth"%>
+<%@page import="org.codelibs.saml2.servlet.ServletUtils"%>
 <%@page import="java.util.List"%>
 <%@page import="java.util.Map"%>
 <%@page import="org.apache.commons.lang3.StringUtils" %>
@@ -91,11 +90,9 @@
 	      				</thead>
 	      				<tbody>
 	    <%
-					Collection<String> keys = attributes.keySet();
-					for(String name :keys){
-						out.println("<tr><td>" + name + "</td><td>");
-						List<String> values = attributes.get(name);
-						for(String value :values) {
+					for (Map.Entry<String, List<String>> entry : attributes.entrySet()) {
+						out.println("<tr><td>" + entry.getKey() + "</td><td>");
+						for(String value : entry.getValue()) {
 							out.println("<li>" + value + "</li>");
 						}
 

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/attrs.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/attrs.jsp
@@ -1,6 +1,4 @@
-<%@page import="org.codelibs.saml2.core.core.toolkit.Auth"%>
-<%@page import="java.util.Collection"%>
-<%@page import="java.util.Enumeration"%>
+<%@page import="org.codelibs.saml2.Auth"%>
 <%@page import="java.util.HashMap"%>
 <%@page import="java.util.List"%>
 <%@page import="java.util.Map"%>
@@ -27,16 +25,7 @@
 	<div class="container">
     	<h1>A Java SAML Toolkit</h1>
 	<%
-		Boolean found = false;
-		@SuppressWarnings("unchecked")
-		Enumeration<String> elems = (Enumeration<String>) session.getAttributeNames();
-
-		while (elems.hasMoreElements() && !found) {
-			String value = (String) elems.nextElement();
-			if (value.equals("attributes") || value.equals("nameId")) {
-				found = true;
-			}
-		}
+		boolean found = session.getAttribute("attributes") != null || session.getAttribute("nameId") != null;
 
 		if (found) {
 			String nameId = (String) session.getAttribute("nameId");
@@ -64,11 +53,9 @@
       				</thead>
       				<tbody>
     		<%
-				Collection<String> keys = attributes.keySet();
-				for(String name :keys){
-					out.println("<tr><td>" + name + "</td><td>");
-					List<String> values = attributes.get(name);
-					for(String value :values) {
+				for (Map.Entry<String, List<String>> entry : attributes.entrySet()) {
+					out.println("<tr><td>" + entry.getKey() + "</td><td>");
+					for(String value : entry.getValue()) {
 						out.println("<li>" + value + "</li>");
 					}
 

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/dologin.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/dologin.jsp
@@ -1,4 +1,4 @@
-<%@page import="org.codelibs.saml2.core.core.toolkit.Auth"%>
+<%@page import="org.codelibs.saml2.Auth"%>
 <%@page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/dologout.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/dologout.jsp
@@ -1,4 +1,5 @@
-<%@page import="org.codelibs.saml2.core.core.toolkit.Auth"%>
+<%@page import="org.codelibs.saml2.Auth"%>
+<%@page import="java.util.Objects"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
@@ -9,26 +10,11 @@
 	<%
 		Auth auth = new Auth(request, response);
 
-		String nameId = null;
-		if (session.getAttribute("nameId") != null) {
-			nameId = session.getAttribute("nameId").toString();
-		}
-		String nameIdFormat = null;
-		if (session.getAttribute("nameIdFormat") != null) {
-			nameIdFormat = session.getAttribute("nameIdFormat").toString();
-		}
-		String nameidNameQualifier = null;
-		if (session.getAttribute("nameidNameQualifier") != null) {
-			nameidNameQualifier = session.getAttribute("nameidNameQualifier").toString();
-		}
-		String nameidSPNameQualifier = null;
-		if (session.getAttribute("nameidSPNameQualifier") != null) {
-			nameidSPNameQualifier = session.getAttribute("nameidSPNameQualifier").toString();
-		}
-		String sessionIndex = null;
-		if (session.getAttribute("sessionIndex") != null) {
-			sessionIndex = session.getAttribute("sessionIndex").toString();
-		}
+		String nameId = Objects.toString(session.getAttribute("nameId"), null);
+		String nameIdFormat = Objects.toString(session.getAttribute("nameIdFormat"), null);
+		String nameidNameQualifier = Objects.toString(session.getAttribute("nameidNameQualifier"), null);
+		String nameidSPNameQualifier = Objects.toString(session.getAttribute("nameidSPNameQualifier"), null);
+		String sessionIndex = Objects.toString(session.getAttribute("sessionIndex"), null);
 		auth.logout(null, nameId, sessionIndex, nameIdFormat, nameidNameQualifier, nameidSPNameQualifier);
 	%>
 </body>

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/metadata.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/metadata.jsp
@@ -1,4 +1,4 @@
-<%@page import="java.util.*,org.codelibs.saml2.core.core.toolkit.Auth,org.codelibs.saml2.core.core.toolkit.settings.Saml2Settings" language="java" contentType="application/xhtml+xml"%><%
+<%@page import="java.util.List,org.codelibs.saml2.Auth,org.codelibs.saml2.core.settings.Saml2Settings" language="java" contentType="application/xhtml+xml"%><%
 Auth auth = new Auth();
 Saml2Settings settings = auth.getSettings();
 settings.setSPValidationOnly(true);

--- a/samples/java-saml-tookit-jspsample/src/main/webapp/sls.jsp
+++ b/samples/java-saml-tookit-jspsample/src/main/webapp/sls.jsp
@@ -1,8 +1,5 @@
-<%@page import="org.codelibs.saml2.core.core.toolkit.Auth"%>
-<%@page import="java.util.Collection"%>
-<%@page import="java.util.HashMap"%>
+<%@page import="org.codelibs.saml2.Auth"%>
 <%@page import="java.util.List"%>
-<%@page import="java.util.Map"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
 <!DOCTYPE html>
@@ -32,7 +29,7 @@
 		List<String> errors = auth.getErrors();
 
 		if (errors.isEmpty()) {
-			out.println("<p>Sucessfully logged out</p>");
+			out.println("<p>Successfully logged out</p>");
 			out.println("<a href=\"dologin.jsp\" class=\"btn btn-primary\">Login</a>");
 		} else {
 			out.println("<p>");

--- a/toolkit/src/main/java/org/codelibs/saml2/Auth.java
+++ b/toolkit/src/main/java/org/codelibs/saml2/Auth.java
@@ -277,8 +277,7 @@ public class Auth {
         // Check settings
         final List<String> settingsErrors = settings.checkSettings();
         if (!settingsErrors.isEmpty()) {
-            String errorMsg = "Invalid settings: ";
-            errorMsg += StringUtils.join(settingsErrors, ", ");
+            final String errorMsg = "Invalid settings: " + StringUtils.join(settingsErrors, ", ");
             LOGGER.warn(errorMsg);
             throw new SettingsException(errorMsg, SettingsException.SETTINGS_INVALID);
         }
@@ -570,32 +569,28 @@ public class Auth {
      * @return the SSO URL with the AuthNRequest if stay = True
      *
      */
-    public String login(String relayState, final AuthnRequestParams authnRequestParams, final Boolean stay,
-            Map<String, String> parameters) {
+    public String login(final String relayState, final AuthnRequestParams authnRequestParams, final Boolean stay,
+            final Map<String, String> parameters) {
         final AuthnRequest authnRequest = samlMessageFactory.createAuthnRequest(settings, authnRequestParams);
 
-        if (parameters == null) {
-            parameters = new HashMap<>();
-        }
+        final Map<String, String> requestParameters = parameters == null ? new HashMap<>() : parameters;
 
         final String samlRequest = authnRequest.getEncodedAuthnRequest();
 
-        parameters.put("SAMLRequest", samlRequest);
+        requestParameters.put("SAMLRequest", samlRequest);
 
-        if (relayState == null) {
-            relayState = ServletUtils.getSelfRoutedURLNoQuery(request);
-        }
+        final String effectiveRelayState = relayState == null ? ServletUtils.getSelfRoutedURLNoQuery(request) : relayState;
 
-        if (!relayState.isEmpty()) {
-            parameters.put("RelayState", relayState);
+        if (!effectiveRelayState.isEmpty()) {
+            requestParameters.put("RelayState", effectiveRelayState);
         }
 
         if (settings.getAuthnRequestsSigned()) {
             final String sigAlg = settings.getSignatureAlgorithm();
-            final String signature = this.buildRequestSignature(samlRequest, relayState, sigAlg);
+            final String signature = this.buildRequestSignature(samlRequest, effectiveRelayState, sigAlg);
 
-            parameters.put("SigAlg", sigAlg);
-            parameters.put("Signature", signature);
+            requestParameters.put("SigAlg", sigAlg);
+            requestParameters.put("Signature", signature);
         }
 
         final String ssoUrl = getSSOurl();
@@ -606,7 +601,7 @@ public class Auth {
         if (!stay) {
             LOGGER.debug("AuthNRequest sent to {} --> {}", ssoUrl, samlRequest);
         }
-        return ServletUtils.sendRedirect(response, ssoUrl, parameters, stay);
+        return ServletUtils.sendRedirect(response, ssoUrl, requestParameters, stay);
     }
 
     /**
@@ -732,31 +727,27 @@ public class Auth {
      * @return the SLO URL with the LogoutRequest if stay = True
      *
      */
-    public String logout(String relayState, final LogoutRequestParams logoutRequestParams, final Boolean stay,
-            Map<String, String> parameters) {
+    public String logout(final String relayState, final LogoutRequestParams logoutRequestParams, final Boolean stay,
+            final Map<String, String> parameters) {
 
-        if (parameters == null) {
-            parameters = new HashMap<>();
-        }
+        final Map<String, String> requestParameters = parameters == null ? new HashMap<>() : parameters;
 
         final LogoutRequest logoutRequest = samlMessageFactory.createOutgoingLogoutRequest(settings, logoutRequestParams);
         final String samlLogoutRequest = logoutRequest.getEncodedLogoutRequest();
-        parameters.put("SAMLRequest", samlLogoutRequest);
+        requestParameters.put("SAMLRequest", samlLogoutRequest);
 
-        if (relayState == null) {
-            relayState = ServletUtils.getSelfRoutedURLNoQuery(request);
-        }
+        final String effectiveRelayState = relayState == null ? ServletUtils.getSelfRoutedURLNoQuery(request) : relayState;
 
-        if (!relayState.isEmpty()) {
-            parameters.put("RelayState", relayState);
+        if (!effectiveRelayState.isEmpty()) {
+            requestParameters.put("RelayState", effectiveRelayState);
         }
 
         if (settings.getLogoutRequestSigned()) {
             final String sigAlg = settings.getSignatureAlgorithm();
-            final String signature = this.buildRequestSignature(samlLogoutRequest, relayState, sigAlg);
+            final String signature = this.buildRequestSignature(samlLogoutRequest, effectiveRelayState, sigAlg);
 
-            parameters.put("SigAlg", sigAlg);
-            parameters.put("Signature", signature);
+            requestParameters.put("SigAlg", sigAlg);
+            requestParameters.put("Signature", signature);
         }
 
         final String sloUrl = getSLOurl();
@@ -767,7 +758,7 @@ public class Auth {
         if (!stay) {
             LOGGER.debug("Logout request sent to {} --> {}", sloUrl, samlLogoutRequest);
         }
-        return ServletUtils.sendRedirect(response, sloUrl, parameters, stay);
+        return ServletUtils.sendRedirect(response, sloUrl, requestParameters, stay);
     }
 
     /**
@@ -1153,7 +1144,7 @@ public class Auth {
             lastMessageIssueInstant = samlResponse.getResponseIssueInstant();
             lastAssertionId = samlResponse.getAssertionId();
             lastAssertionNotOnOrAfter = samlResponse.getAssertionNotOnOrAfter();
-            LOGGER.debug("processResponse success --> " + samlResponseParameter);
+            LOGGER.debug("processResponse success --> {}", samlResponseParameter);
         } else {
             errorReason = samlResponse.getError();
             validationException = samlResponse.getValidationException();
@@ -1226,7 +1217,7 @@ public class Auth {
                 } else {
                     lastMessageId = logoutResponse.getId();
                     lastMessageIssueInstant = logoutResponse.getIssueInstant();
-                    LOGGER.debug("processSLO success --> " + samlResponseParameter);
+                    LOGGER.debug("processSLO success --> {}", samlResponseParameter);
                     if (!keepLocalSession) {
                         request.getSession().invalidate();
                     }
@@ -1244,50 +1235,48 @@ public class Auth {
                 errorReason = logoutRequest.getError();
                 validationException = logoutRequest.getValidationException();
                 return null;
-            } else {
-                lastMessageId = logoutRequest.getId();
-                lastMessageIssueInstant = logoutRequest.getIssueInstant();
-                LOGGER.debug("processSLO success --> " + samlRequestParameter);
-                if (!keepLocalSession) {
-                    request.getSession().invalidate();
-                }
-
-                final String inResponseTo = logoutRequest.id;
-                final LogoutResponse logoutResponseBuilder = samlMessageFactory.createOutgoingLogoutResponse(settings,
-                        new LogoutResponseParams(inResponseTo, Constants.STATUS_SUCCESS));
-                lastResponse = logoutResponseBuilder.getLogoutResponseXml();
-
-                final String samlLogoutResponse = logoutResponseBuilder.getEncodedLogoutResponse();
-
-                final Map<String, String> parameters = new LinkedHashMap<>();
-
-                parameters.put("SAMLResponse", samlLogoutResponse);
-
-                final String relayState = request.getParameter("RelayState");
-                if (relayState != null) {
-                    parameters.put("RelayState", relayState);
-                }
-
-                if (settings.getLogoutResponseSigned()) {
-                    final String sigAlg = settings.getSignatureAlgorithm();
-                    final String signature = this.buildResponseSignature(samlLogoutResponse, relayState, sigAlg);
-
-                    parameters.put("SigAlg", sigAlg);
-                    parameters.put("Signature", signature);
-                }
-
-                final String sloUrl = getSLOResponseUrl();
-
-                if (!stay) {
-                    LOGGER.debug("Logout response sent to {} --> {}", sloUrl, samlLogoutResponse);
-                }
-                return ServletUtils.sendRedirect(response, sloUrl, parameters, stay);
             }
-        } else {
-            errors.add("invalid_binding");
-            final String errorMsg = "SAML LogoutRequest/LogoutResponse not found. Only supported HTTP_REDIRECT Binding";
-            throw new SAMLSevereException(errorMsg, SAMLSevereException.SAML_LOGOUTMESSAGE_NOT_FOUND);
+            lastMessageId = logoutRequest.getId();
+            lastMessageIssueInstant = logoutRequest.getIssueInstant();
+            LOGGER.debug("processSLO success --> {}", samlRequestParameter);
+            if (!keepLocalSession) {
+                request.getSession().invalidate();
+            }
+
+            final String inResponseTo = logoutRequest.getId();
+            final LogoutResponse logoutResponseBuilder = samlMessageFactory.createOutgoingLogoutResponse(settings,
+                    new LogoutResponseParams(inResponseTo, Constants.STATUS_SUCCESS));
+            lastResponse = logoutResponseBuilder.getLogoutResponseXml();
+
+            final String samlLogoutResponse = logoutResponseBuilder.getEncodedLogoutResponse();
+
+            final Map<String, String> parameters = new LinkedHashMap<>();
+
+            parameters.put("SAMLResponse", samlLogoutResponse);
+
+            final String relayState = request.getParameter("RelayState");
+            if (relayState != null) {
+                parameters.put("RelayState", relayState);
+            }
+
+            if (settings.getLogoutResponseSigned()) {
+                final String sigAlg = settings.getSignatureAlgorithm();
+                final String signature = this.buildResponseSignature(samlLogoutResponse, relayState, sigAlg);
+
+                parameters.put("SigAlg", sigAlg);
+                parameters.put("Signature", signature);
+            }
+
+            final String sloUrl = getSLOResponseUrl();
+
+            if (!stay) {
+                LOGGER.debug("Logout response sent to {} --> {}", sloUrl, samlLogoutResponse);
+            }
+            return ServletUtils.sendRedirect(response, sloUrl, parameters, stay);
         }
+        errors.add("invalid_binding");
+        final String errorMsg = "SAML LogoutRequest/LogoutResponse not found. Only supported HTTP_REDIRECT Binding";
+        throw new SAMLSevereException(errorMsg, SAMLSevereException.SAML_LOGOUTMESSAGE_NOT_FOUND);
     }
 
     /**
@@ -1551,7 +1540,7 @@ public class Auth {
      * @return the base64 encoded signature
      *
      */
-    private String buildSignature(final String samlMessage, final String relayState, String signAlgorithm, final String type) {
+    private String buildSignature(final String samlMessage, final String relayState, final String signAlgorithm, final String type) {
         String signature = "";
 
         if (!settings.checkSPCerts()) {
@@ -1562,19 +1551,17 @@ public class Auth {
 
         final PrivateKey key = settings.getSPkey();
 
-        StringBuilder msg = new StringBuilder().append(type).append("=").append(Util.urlEncoder(samlMessage));
+        final StringBuilder msg = new StringBuilder().append(type).append("=").append(Util.urlEncoder(samlMessage));
         if (StringUtils.isNotEmpty(relayState)) {
             msg.append("&RelayState=").append(Util.urlEncoder(relayState));
         }
 
-        if (StringUtils.isEmpty(signAlgorithm)) {
-            signAlgorithm = Constants.RSA_SHA1;
-        }
+        final String algorithm = StringUtils.isEmpty(signAlgorithm) ? Constants.RSA_SHA1 : signAlgorithm;
 
-        msg.append("&SigAlg=").append(Util.urlEncoder(signAlgorithm));
+        msg.append("&SigAlg=").append(Util.urlEncoder(algorithm));
 
         try {
-            signature = Util.base64encoder(Util.sign(msg.toString(), key, signAlgorithm));
+            signature = Util.base64encoder(Util.sign(msg.toString(), key, algorithm));
         } catch (InvalidKeyRuntimeException | NoSuchAlgorithmRuntimeException | SAMLSignatureException e) {
             final String errorMsg = "buildSignature error." + e.getMessage();
             LOGGER.warn(errorMsg, e);

--- a/toolkit/src/main/java/org/codelibs/saml2/servlet/ServletUtils.java
+++ b/toolkit/src/main/java/org/codelibs/saml2/servlet/ServletUtils.java
@@ -154,32 +154,33 @@ public class ServletUtils {
      * @see jakarta.servlet.http.HttpServletResponse#sendRedirect(String)
      */
     public static String sendRedirect(HttpServletResponse response, String location, Map<String, String> parameters, Boolean stay) {
-        String target = location;
+        final StringBuilder target = new StringBuilder(location);
 
         if (!parameters.isEmpty()) {
             boolean first = !location.contains("?");
             for (Map.Entry<String, String> parameter : parameters.entrySet()) {
                 if (first) {
-                    target += "?";
+                    target.append("?");
                     first = false;
                 } else {
-                    target += "&";
+                    target.append("&");
                 }
-                target += parameter.getKey();
+                target.append(parameter.getKey());
                 if (!parameter.getValue().isEmpty()) {
-                    target += "=" + Util.urlEncoder(parameter.getValue());
+                    target.append("=").append(Util.urlEncoder(parameter.getValue()));
                 }
             }
         }
+        final String targetUrl = target.toString();
         if (!stay) {
             try {
-                response.sendRedirect(target);
+                response.sendRedirect(targetUrl);
             } catch (IOException e) {
                 throw new IORuntimeException(e);
             }
         }
 
-        return target;
+        return targetUrl;
     }
 
     /**
@@ -211,7 +212,7 @@ public class ServletUtils {
      * @see HttpServletResponse#sendRedirect(String)
      */
     public static void sendRedirect(HttpServletResponse response, String location) {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         sendRedirect(response, location, parameters);
     }
 }

--- a/toolkit/src/test/java/org/codelibs/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/org/codelibs/saml2/test/AuthTest.java
@@ -118,7 +118,7 @@ public class AuthTest {
      * @throws IOException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth
+     * @see org.codelibs.saml2.Auth
      */
     @Test
     public void testConstructor() throws IOException, SettingsException, SAMLSevereException {
@@ -139,7 +139,7 @@ public class AuthTest {
      * @throws IOException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth
+     * @see org.codelibs.saml2.Auth
      */
     @Test
     public void testConstructorWithFilename() throws IOException, SettingsException, SAMLSevereException {
@@ -163,7 +163,7 @@ public class AuthTest {
      * @throws KeyStoreException 
      * @throws UnrecoverableKeyException 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth
+     * @see org.codelibs.saml2.Auth
      */
     @Test
     public void testConstructorWithFilenameAndKeyStore() throws IOException, SettingsException, SAMLSevereException,
@@ -188,7 +188,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth
+     * @see org.codelibs.saml2.Auth
      */
     @Test
     public void testConstructorWithReqRes() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -217,7 +217,7 @@ public class AuthTest {
      * @throws CertificateException 
      * @throws NoSuchAlgorithmException 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth
+     * @see org.codelibs.saml2.Auth
      */
     @Test
     public void testConstructorWithReqResAndKeyStore() throws IOException, SettingsException, URISyntaxException, SAMLSevereException,
@@ -244,7 +244,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth
+     * @see org.codelibs.saml2.Auth
      */
     @Test
     public void testConstructorWithFilenameReqRes() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -270,7 +270,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth
+     * @see org.codelibs.saml2.Auth
      */
     @Test
     public void testConstructorWithSettingsReqRes() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -294,7 +294,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth
+     * @see org.codelibs.saml2.Auth
      */
     @Test
     public void testConstructorInvalidSettings() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -318,7 +318,7 @@ public class AuthTest {
      * @throws IOException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getSettings
+     * @see org.codelibs.saml2.Auth#getSettings
      */
     @Test
     public void testGetSettings() throws IOException, SettingsException, SAMLSevereException {
@@ -348,7 +348,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#setStrict
+     * @see org.codelibs.saml2.Auth#setStrict
      */
     @Test
     public void testSetStrict() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -369,7 +369,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#setReplayCache
+     * @see org.codelibs.saml2.Auth#setReplayCache
      */
     @Test
     public void testSetReplayCache() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -389,7 +389,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#isDebugActive
+     * @see org.codelibs.saml2.Auth#isDebugActive
      */
     @Test
     public void testIsDebugActive() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -417,7 +417,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getSSOurl
+     * @see org.codelibs.saml2.Auth#getSSOurl
      */
     @Test
     public void testGetSSOurl() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -440,7 +440,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getSLOurl
+     * @see org.codelibs.saml2.Auth#getSLOurl
      */
     @Test
     public void testGetSLOurl() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -463,7 +463,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getSLOResponseUrl
+     * @see org.codelibs.saml2.Auth#getSLOResponseUrl
      */
     @Test
     public void testGetSLOResponseUrl() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -486,7 +486,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getSLOResponseUrl
+     * @see org.codelibs.saml2.Auth#getSLOResponseUrl
      */
     @Test
     public void testGetSLOResponseUrlNull() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -506,7 +506,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processResponse
+     * @see org.codelibs.saml2.Auth#processResponse
      */
     @Test
     public void testProcessNoResponse() throws Exception {
@@ -535,10 +535,10 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processResponse
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getAttributes
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getAttribute
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getAttributesName
+     * @see org.codelibs.saml2.Auth#processResponse
+     * @see org.codelibs.saml2.Auth#getAttributes
+     * @see org.codelibs.saml2.Auth#getAttribute
+     * @see org.codelibs.saml2.Auth#getAttributesName
      */
     @Test
     public void testProcessResponse() throws Exception {
@@ -598,7 +598,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessResponseStatusResponder() throws Exception {
@@ -632,7 +632,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLONoMessage() throws Exception {
@@ -662,7 +662,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLORequestKeepSession() throws Exception {
@@ -692,7 +692,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLORequestRemoveSession() throws Exception {
@@ -721,7 +721,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLORequestStay() throws Exception {
@@ -750,7 +750,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLORequestStayFalse() throws Exception {
@@ -782,7 +782,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLORequestStayTrue() throws Exception {
@@ -812,7 +812,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLORequestSignRes() throws Exception {
@@ -848,7 +848,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLORequestInvalid() throws Exception {
@@ -879,7 +879,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLOResponseKeepSession() throws Exception {
@@ -906,7 +906,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLOResponseRemoveSession() throws Exception {
@@ -933,7 +933,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLOResponseWrongRequestId() throws Exception {
@@ -964,7 +964,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#processSLO
+     * @see org.codelibs.saml2.Auth#processSLO
      */
     @Test
     public void testProcessSLOResponseStatusResponder() throws Exception {
@@ -992,9 +992,9 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#isAuthenticated
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getErrors
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getLastErrorReason
+     * @see org.codelibs.saml2.Auth#isAuthenticated
+     * @see org.codelibs.saml2.Auth#getErrors
+     * @see org.codelibs.saml2.Auth#getLastErrorReason
      */
     @Test
     public void testIsAuthenticated() throws Exception {
@@ -1049,7 +1049,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getNameId
+     * @see org.codelibs.saml2.Auth#getNameId
      */
     @Test
     public void testGetNameID() throws Exception {
@@ -1091,7 +1091,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getNameIdFormat
+     * @see org.codelibs.saml2.Auth#getNameIdFormat
      */
     @Test
     public void testGetNameIdFormat() throws Exception {
@@ -1132,7 +1132,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getNameIdNameQualifier
+     * @see org.codelibs.saml2.Auth#getNameIdNameQualifier
      */
     @Test
     public void testGetNameIdNameQualifier() throws Exception {
@@ -1163,7 +1163,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getNameIdSPNameQualifier
+     * @see org.codelibs.saml2.Auth#getNameIdSPNameQualifier
      */
     @Test
     public void testGetNameIdSPNameQualifier() throws Exception {
@@ -1194,7 +1194,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.authn.SamlResponse#getNameId
+     * @see org.codelibs.saml2.core.authn.SamlResponse#getNameId
      */
     @Test
     public void testGetNameIDEncWithNoKey() throws Exception {
@@ -1216,7 +1216,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.authn.SamlResponse#getAttributes
+     * @see org.codelibs.saml2.core.authn.SamlResponse#getAttributes
      */
     @Test
     public void testOnlyRetrieveAssertionWithIDThatMatchesSignatureReference() throws Exception {
@@ -1239,7 +1239,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getSessionIndex
+     * @see org.codelibs.saml2.Auth#getSessionIndex
      */
     @Test
     public void testGetSessionIndex() throws Exception {
@@ -1286,7 +1286,7 @@ public class AuthTest {
      *
      * @throws Exception
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getSessionExpiration
+     * @see org.codelibs.saml2.Auth#getSessionExpiration
      */
     @Test
     public void testGetSessionExpiration() throws Exception {
@@ -1321,7 +1321,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#login
+     * @see org.codelibs.saml2.Auth#login
      */
     @Test
     public void testLogin() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -1350,7 +1350,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#login
+     * @see org.codelibs.saml2.Auth#login
      */
     @Test
     public void testLoginWithRelayState() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -1380,7 +1380,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#login
+     * @see org.codelibs.saml2.Auth#login
      */
     @Test
     public void testLoginWithoutRelayState() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -1411,7 +1411,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#login
+     * @see org.codelibs.saml2.Auth#login
      */
     @Test
     public void testLoginWithExtraParameters() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -1442,7 +1442,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#login
+     * @see org.codelibs.saml2.Auth#login
      */
     @Test
     public void testLoginStay() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -1476,7 +1476,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#login
+     * @see org.codelibs.saml2.Auth#login
      */
     @Test
     public void testLoginSubject() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -1527,7 +1527,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#login
+     * @see org.codelibs.saml2.Auth#login
      */
     @Test
     public void testLoginSignedFail() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -1556,7 +1556,7 @@ public class AuthTest {
      * @throws URISyntaxException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#login
+     * @see org.codelibs.saml2.Auth#login
      */
     @Test
     public void testLoginSigned() throws IOException, SettingsException, URISyntaxException, SAMLSevereException {
@@ -1592,7 +1592,7 @@ public class AuthTest {
      * @throws XMLSecurityException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#logout
+     * @see org.codelibs.saml2.Auth#logout
      */
     @Test
     public void testLogout() throws IOException, SettingsException, XMLSecurityException, SAMLSevereException {
@@ -1622,7 +1622,7 @@ public class AuthTest {
      * @throws XMLSecurityException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#logout
+     * @see org.codelibs.saml2.Auth#logout
      */
     @Test
     public void testLogoutWithExtraParameters() throws IOException, SettingsException, XMLSecurityException, SAMLSevereException {
@@ -1652,7 +1652,7 @@ public class AuthTest {
      * @throws XMLSecurityException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#logout
+     * @see org.codelibs.saml2.Auth#logout
      */
     @Test
     public void testLogoutWithRelayState() throws IOException, SettingsException, XMLSecurityException, SAMLSevereException {
@@ -1683,7 +1683,7 @@ public class AuthTest {
      * @throws XMLSecurityException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#logout
+     * @see org.codelibs.saml2.Auth#logout
      */
     @Test
     public void testLogoutWithoutRelayState() throws IOException, SettingsException, XMLSecurityException, SAMLSevereException {
@@ -1715,7 +1715,7 @@ public class AuthTest {
      * @throws XMLSecurityException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#logout
+     * @see org.codelibs.saml2.Auth#logout
      */
     @Test
     public void testLogoutStay() throws IOException, SettingsException, XMLSecurityException, SAMLSevereException {
@@ -1749,7 +1749,7 @@ public class AuthTest {
      * @throws XMLSecurityException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#logout
+     * @see org.codelibs.saml2.Auth#logout
      */
     @Test
     public void testLogoutSignedFail() throws IOException, SettingsException, XMLSecurityException, SAMLSevereException {
@@ -1778,7 +1778,7 @@ public class AuthTest {
      * @throws XMLSecurityException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#logout
+     * @see org.codelibs.saml2.Auth#logout
      */
     @Test
     public void testLogoutSigned() throws IOException, SettingsException, XMLSecurityException, SAMLSevereException {
@@ -1814,7 +1814,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildRequestSignature
+     * @see org.codelibs.saml2.Auth#buildRequestSignature
      */
     @Test
     public void testBuildRequestSignatureInvalidSP() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -1838,7 +1838,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildRequestSignature
+     * @see org.codelibs.saml2.Auth#buildRequestSignature
      */
     @Test
     public void testBuildRequestSignatureRsaSha1() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -1865,7 +1865,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildRequestSignature
+     * @see org.codelibs.saml2.Auth#buildRequestSignature
      */
     @Test(expected = IllegalArgumentException.class)
     public void testBuildRequestSignatureDsaSha1() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -1886,7 +1886,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildRequestSignature
+     * @see org.codelibs.saml2.Auth#buildRequestSignature
      */
     @Test
     public void testBuildRequestSignatureRsaSha256() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -1910,7 +1910,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildRequestSignature
+     * @see org.codelibs.saml2.Auth#buildRequestSignature
      */
     @Test
     public void testBuildRequestSignatureRsaSha384() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -1934,7 +1934,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildRequestSignature
+     * @see org.codelibs.saml2.Auth#buildRequestSignature
      */
     @Test
     public void testBuildRequestSignatureRsaSha512() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -1958,7 +1958,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildResponseSignature
+     * @see org.codelibs.saml2.Auth#buildResponseSignature
      */
     @Test
     public void testBuildResponseSignatureRsaSha1() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -1985,7 +1985,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildResponseSignature
+     * @see org.codelibs.saml2.Auth#buildResponseSignature
      */
     @Test(expected = IllegalArgumentException.class)
     public void testBuildResponseSignatureDsaSha1() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -2006,7 +2006,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildResponseSignature
+     * @see org.codelibs.saml2.Auth#buildResponseSignature
      */
     @Test
     public void testBuildResponseSignatureRsaSha256() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -2030,7 +2030,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildResponseSignature
+     * @see org.codelibs.saml2.Auth#buildResponseSignature
      */
     @Test
     public void testBuildResponseSignatureRsaSha384() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -2054,7 +2054,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildResponseSignature
+     * @see org.codelibs.saml2.Auth#buildResponseSignature
      */
     @Test
     public void testBuildResponseSignatureRsaSha512() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -2077,7 +2077,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#buildSignature
+     * @see org.codelibs.saml2.Auth#buildSignature
      */
     @Test
     public void testBuildSignature() throws URISyntaxException, IOException, SettingsException, SAMLSevereException {
@@ -2148,7 +2148,7 @@ public class AuthTest {
      * @throws SettingsException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getLastRequestXML
+     * @see org.codelibs.saml2.Auth#getLastRequestXML
      */
     @Test
     public void testGetLastAuthNRequest() throws IOException, SettingsException, SAMLSevereException {
@@ -2175,7 +2175,7 @@ public class AuthTest {
      * @throws XMLSecurityException
      * @throws Error
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getLastRequestXML
+     * @see org.codelibs.saml2.Auth#getLastRequestXML
      */
     @Test
     public void testGetLastLogoutRequestSent() throws IOException, SettingsException, XMLSecurityException, SAMLSevereException {
@@ -2199,7 +2199,7 @@ public class AuthTest {
      *
      * @throws Exception 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getLastRequestXML
+     * @see org.codelibs.saml2.Auth#getLastRequestXML
      */
     @Test
     public void testGetLastLogoutRequestReceived() throws Exception {
@@ -2222,7 +2222,7 @@ public class AuthTest {
      *
      * @throws Exception
      * 
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getLastResponseXML
+     * @see org.codelibs.saml2.Auth#getLastResponseXML
      */
     @Test
     public void testGetLastSAMLResponse() throws Exception {
@@ -2253,7 +2253,7 @@ public class AuthTest {
      *
      * @throws Exception 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getLastResponseXML
+     * @see org.codelibs.saml2.Auth#getLastResponseXML
      */
     @Test
     public void testGetLastLogoutResponseSent() throws Exception {
@@ -2277,7 +2277,7 @@ public class AuthTest {
      *
      * @throws Exception 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#getLastResponseXML
+     * @see org.codelibs.saml2.Auth#getLastResponseXML
      */
     @Test
     public void testGetLastLogoutResponseReceived() throws Exception {
@@ -2302,7 +2302,7 @@ public class AuthTest {
      *
      * @throws Exception 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#setAuthnRequestFactory(org.codelibs.saml2.core.core.toolkit.factory.SamlOutgoingMessageFactory)
+     * @see org.codelibs.saml2.Auth#setAuthnRequestFactory(org.codelibs.saml2.factory.SamlOutgoingMessageFactory)
      */
     @Test(expected = FactoryInvokedException.class)
     public void testAuthnRequestFactory() throws Exception {
@@ -2336,7 +2336,7 @@ public class AuthTest {
      *
      * @throws Exception 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#setSamlResponseFactory(org.codelibs.saml2.core.core.toolkit.factory.SamlReceivedMessageFactory)
+     * @see org.codelibs.saml2.Auth#setSamlResponseFactory(org.codelibs.saml2.factory.SamlReceivedMessageFactory)
      */
     @Test(expected = FactoryInvokedException.class)
     public void testSamlResponseFactory() throws Exception {
@@ -2373,7 +2373,7 @@ public class AuthTest {
      *
      * @throws Exception 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#setOutgoingLogoutRequestFactory(org.codelibs.saml2.core.core.toolkit.factory.SamlOutgoingMessageFactory)
+     * @see org.codelibs.saml2.Auth#setOutgoingLogoutRequestFactory(org.codelibs.saml2.factory.SamlOutgoingMessageFactory)
      */
     @Test(expected = FactoryInvokedException.class)
     public void testOutgoingLogoutRequestFactory() throws Exception {
@@ -2409,7 +2409,7 @@ public class AuthTest {
      *
      * @throws Exception 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#setReceivedLogoutRequestFactory(org.codelibs.saml2.core.core.toolkit.factory.SamlReceivedMessageFactory)
+     * @see org.codelibs.saml2.Auth#setReceivedLogoutRequestFactory(org.codelibs.saml2.factory.SamlReceivedMessageFactory)
      */
     @Test(expected = FactoryInvokedException.class)
     public void testIncomingLogoutRequestFactory() throws Exception {
@@ -2449,7 +2449,7 @@ public class AuthTest {
      *
      * @throws Exception 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#setOutgoingLogoutResponseFactory(org.codelibs.saml2.core.core.toolkit.factory.SamlOutgoingMessageFactory)
+     * @see org.codelibs.saml2.Auth#setOutgoingLogoutResponseFactory(org.codelibs.saml2.factory.SamlOutgoingMessageFactory)
      */
     @Test(expected = FactoryInvokedException.class)
     public void testOutgoingLogoutResponseFactory() throws Exception {
@@ -2493,7 +2493,7 @@ public class AuthTest {
      *
      * @throws Exception 
      *
-     * @see org.codelibs.saml2.core.core.toolkit.Auth#setReceivedLogoutResponseFactory(org.codelibs.saml2.core.core.toolkit.factory.SamlReceivedMessageFactory)
+     * @see org.codelibs.saml2.Auth#setReceivedLogoutResponseFactory(org.codelibs.saml2.factory.SamlReceivedMessageFactory)
      */
     @Test(expected = FactoryInvokedException.class)
     public void testIncomingLogoutResponseFactory() throws Exception {


### PR DESCRIPTION
## Summary

Behavior-preserving refactor that brings the java-saml sources in line with
standard Java coding conventions and cleans up inconsistent / non-idiomatic
code. **No external interface changes** — every `public`/`protected` class,
method, field, constant, and enum keeps its name, signature, and value, so
downstream consumers compile and link unchanged. The full test suite passes
with the same counts as before (**core 415, toolkit 92, 0 failures**).

Scope was limited to naming fixes, safe idiom modernization, and dead-code
removal (no functional/behavioral changes, no default-value or security
changes).

## Naming

Renamed only local variables, private fields, and private methods that
violated Java naming conventions; **public accessor names were left exactly
as-is** for compatibility:

- The trigger case: the leading-uppercase local `AssertionDataNodes` →
  `assertionDataNodes` in `SamlResponse`.
- snake_case → camelCase (`cert_begin`/`end_cert` → `certBegin`/`certEnd`).
- acronym casing on private fields (`nameID`, `spX509cert`,
  `wantXMLValidation`, `uniqueIDPrefix`, `idpx509cert`, …) — public getters
  such as `getWantXMLValidation` / `getUniqueIDPrefix` / `getSPcert` are
  unchanged; only the private fields they read were renamed.
- typos (`errorAcumulator`, `stausCode`, `childs`, `decompresser`,
  `idpDescryptorXPath`, `idvalue`, …).

## Idioms (behavior-preserving)

- `size() != 0` → `isEmpty()`; `x != null && !x.isEmpty()` →
  `StringUtils.isNotEmpty(x)`.
- Hoisted per-call `HashSet` construction into static `Set.of(...)` fields.
- `if (…) return true; return false;` → `return <expr>;`; `if/else`
  assign-then-return → ternary.
- Dropped redundant boxing / `.toString()` / parentheses / generic
  type-witnesses.
- Explicit `"UTF-8"` / `Charset.forName("UTF-8")` → `StandardCharsets.UTF_8`
  (byte-identical output).
- Parameterized SLF4J logging (`"… " + v` → `"… {}", v`) with identical
  rendered text and identical throwable handling.
- Canonical modifier order `public static final` (was `public final static`)
  on the `SettingsBuilder` property-key constants — names, types, and values
  unchanged.

## Dead code

- Removed an unused `LOGGER` field and its imports in `IdPMetadataParser`.
- Deleted a commented-out method block and an unused parameter in
  `SettingsBuilder`.
- Removed dead commented-out debug lines in `SamlResponse`.

## Samples and tests

- Fixed broken package imports in the sample JSPs — they referenced a
  non-existent package (a leftover rename artifact) and could not have
  compiled at runtime.
- Corrected stale `@see` javadoc package paths in `AuthTest` (comment-only).

## Compatibility and safety notes

- One null-contract subtlety was handled explicitly: after hoisting the
  algorithm whitelist to an immutable `Set.of(...)`,
  `Util.isAlgorithmWhitelisted(null)` is guarded to keep returning `false`
  (an immutable set would otherwise throw on `contains(null)`, where the
  previous `HashSet` returned `false`).
- The public API surface was independently reviewed to confirm no accessor
  name, constant name/value, return type, or `throws` clause changed.

## Testing

- `mvn -B test` — **core 415, toolkit 92, 0 failures / 0 errors / 0 skipped**,
  matching the pre-refactor baseline (no tests added or removed; behavior
  unchanged).
