### PR TITLE
fix: do not warn about a rejection the caller is already given

### DIFF
--- a/core/src/main/java/org/codelibs/saml2/core/authn/SamlResponse.java
+++ b/core/src/main/java/org/codelibs/saml2/core/authn/SamlResponse.java
@@ -364,7 +364,13 @@ public class SamlResponse {
         } catch (final Exception e) {
             validationException = e;
             LOGGER.debug("SAMLResponse invalid --> {}", samlResponseString);
-            LOGGER.warn(validationException.getMessage());
+            // Debug rather than warn: the failure is handed to the caller through
+            // getValidationException(), and a false return value is the answer this method was
+            // asked for. A caller that tries several request ids -- the InResponseTo comparison
+            // is the one failure worth retrying with the next candidate -- would otherwise log a
+            // warning for every candidate it rules out, including on the login that then
+            // succeeds. What reaches an operator is for the caller to decide.
+            LOGGER.debug("SAMLResponse validation failed: {}", validationException.getMessage());
             return false;
         }
     }

--- a/core/src/main/java/org/codelibs/saml2/core/util/Util.java
+++ b/core/src/main/java/org/codelibs/saml2/core/util/Util.java
@@ -185,7 +185,13 @@ public final class Util {
             }
             LOGGER.warn("Detected use of ENTITY in XML, disabled to prevent XXE/XEE attacks");
         } catch (final Exception e) {
-            LOGGER.warn("Load XML error: {}", e.getMessage(), e);
+            // The message stays at warn because this method answers with null and drops the
+            // exception, so nothing else would record it. The stack trace moves to debug: the
+            // input is whatever was posted to a service provider's assertion consumer service,
+            // which is anonymous, so an unauthenticated client could otherwise fill the log with
+            // a full trace per request.
+            LOGGER.warn("Load XML error: {}", e.getMessage());
+            LOGGER.debug("Load XML error.", e);
         }
 
         return null;

--- a/toolkit/src/main/java/org/codelibs/saml2/Auth.java
+++ b/toolkit/src/main/java/org/codelibs/saml2/Auth.java
@@ -1151,16 +1151,21 @@ public class Auth {
             final SamlResponseStatus samlResponseStatus = samlResponse.getResponseStatus();
             if (samlResponseStatus.getStatusCode() == null || !Constants.STATUS_SUCCESS.equals(samlResponseStatus.getStatusCode())) {
                 errors.add("response_not_success");
-                LOGGER.warn("processResponse error. sso_not_success");
-                LOGGER.debug(" --> {}", samlResponseParameter);
+                // Debug rather than warn: "response_not_success" is already in getErrors(), and
+                // the detail is in getLastErrorReason() and getLastValidationException(). Logging
+                // it here as well reports the same rejection twice, once at a level the caller
+                // does not control.
+                LOGGER.debug("processResponse error. sso_not_success --> {}", samlResponseParameter);
                 errors.add(samlResponseStatus.getStatusCode());
                 if (samlResponseStatus.getSubStatusCode() != null) {
                     errors.add(samlResponseStatus.getSubStatusCode());
                 }
             } else {
                 errors.add("invalid_response");
-                LOGGER.warn("processResponse error. invalid_response");
-                LOGGER.debug(" --> {}", samlResponseParameter);
+                // Debug for the same reason as above. This is also the line a caller that tries
+                // several request ids hits for every candidate it rules out, so at warn it
+                // reports an error on logins that go on to succeed.
+                LOGGER.debug("processResponse error. invalid_response --> {}", samlResponseParameter);
             }
         }
     }


### PR DESCRIPTION
## Problem

Three places report the same rejection twice — once by returning it to the caller, and once by
logging it at `warn`, at a level the caller does not control.

| Site | Handed to the caller | Also logged |
|---|---|---|
| `SamlResponse#isValid` | `validationException` + `false` | `warn(message)` |
| `Auth#processResponse` | `getErrors()`, `getLastErrorReason()`, `getLastValidationException()` | `warn("processResponse error. …")` |
| `Util#loadXML` | **nothing** — returns `null`, drops the exception | `warn(message, e)` — full stack trace |

Two consequences show up in practice.

**A caller with several candidate request ids logs errors on a login that succeeds.** The
InResponseTo comparison is the one failure worth retrying with the next candidate, so a service
provider whose user has two browser tabs mid-login rules candidates out as a matter of course. At
`warn`, every ruled-out candidate produced

```
The InResponseTo of the Response: …, does not match the ID of the AuthNRequest sent by the SP: …
processResponse error. invalid_response
```

on the way to a successful authentication.

**An anonymous client can write a full stack trace into the log on every request.** The assertion
consumer service is unauthenticated by nature, so anything posted there reaches `Util#loadXML`. A
SAMLResponse that is not parsable produced a 94-line trace per request.

## Change

`SamlResponse#isValid` and `Auth#processResponse` move their lines to `debug`. Everything they
said is still reachable through the public API, so nothing is lost — the caller decides what an
operator sees.

`Util#loadXML` is the opposite case and keeps its message at `warn`, because it answers with
`null` and drops the exception, so nothing else would record it. Only the stack trace moves to
`debug`.

## Verification

Measured against Fess 15.8 with Keycloak 26.4, before and after:

| Scenario | Before | After |
|---|---|---|
| Unparsable SAMLResponse posted to the ACS | 94 stack-trace lines | 0, one message-only line |
| Two-tab login, older tab answered first | succeeds, 2 warnings | succeeds, silent |

The consuming service provider still reports both cases itself, so no diagnosis was lost — only
the duplicate.

```
core     415/415
toolkit   92/92
```

## Note

The repository has no log-capturing test infrastructure, so the level change is not pinned by a
unit test; adding an appender harness for it seemed disproportionate. Say the word if you would
rather have one — the behaviour is covered end to end in the measurement above.
